### PR TITLE
feat: Conversation message list table formatter

### DIFF
--- a/Common/config/formatter-plugins.config.php
+++ b/Common/config/formatter-plugins.config.php
@@ -126,6 +126,7 @@ use Common\Service\Table\Formatter\EbsrRegNumberLinkFactory;
 use Common\Service\Table\Formatter\EbsrVariationNumberFactory;
 use Common\Service\Table\Formatter\EventHistoryDescriptionFactory;
 use Common\Service\Table\Formatter\EventHistoryUserFactory;
+use Common\Service\Table\Formatter\ExternalConversationMessage;
 use Common\Service\Table\Formatter\FeatureToggleEditLinkFactory;
 use Common\Service\Table\Formatter\FeeAmountSumFactory;
 use Common\Service\Table\Formatter\FeeIdUrlFactory;
@@ -262,6 +263,7 @@ return [
         Date::class => Date::class,
         DateTime::class => DateTime::class,
         DocumentSubcategory::class => DocumentSubcategory::class,
+        ExternalConversationMessage::class => ExternalConversationMessage::class,
         FeeAmount::class => FeeAmount::class,
         FeeStatus::class => FeeStatus::class,
         FileExtension::class => FileExtension::class,

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Table\Formatter;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+
+class ExternalConversationMessage implements FormatterPluginManagerInterface
+{
+    /**
+     * status
+     *
+     * @param array $row    Row data
+     * @param array $column Column data
+     *
+     * @return     string
+     * @inheritdoc
+     */
+    public function format($row, $column = null): string
+    {
+        if (!empty($row['createdBy']['team'])) {
+            $senderName = 'Case Worker';
+        } elseif (!empty($row['createdBy']['contactDetails']['person'])) {
+            $person = $row['createdBy']['contactDetails']['person'];
+            $senderName = $person['forename'] . " " . $person['familyName'];
+        } else {
+            $senderName = $row['createdBy']['loginId'];
+        }
+
+        $latestMessageCreatedAt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $row["createdOn"]);
+        $date = $latestMessageCreatedAt->format('l j F Y \a\t H:ia');
+
+        $rowTemplate = '
+            <div class="govuk-!-margin-bottom-6">
+                <div class="govuk-summary-card">
+                    <div class="govuk-summary-card__title-wrapper">
+                        <h2 class="govuk-summary-card__title">%s</h2>
+                        <h2 class="govuk-summary-card__title govuk-summary-card__date">%s</h2>
+                    </div>
+                    <div class="govuk-summary-card__content">
+                        <p class="govuk-body">%s</p>
+                    </div>
+                </div>
+            </div>
+        ';
+
+        return vsprintf(
+            $rowTemplate,
+            [
+                $senderName,
+                $date,
+                nl2br($row['messagingContent']['text'])
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Description

Case worker can select a conversation, they are then taken to a page where they can view the messages related to that conversation.

Related issue: [VOL-4805](https://dvsa.atlassian.net/browse/VOL-4805)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
