### PR TITLE
fix: fix `GenerateContinuationDetails` `service_name`

### DIFF
--- a/Common/src/Common/Form/Model/Fieldset/GenerateContinuationDetails.php
+++ b/Common/src/Common/Form/Model/Fieldset/GenerateContinuationDetails.php
@@ -39,7 +39,7 @@ class GenerateContinuationDetails
      * @Form\Options({
      *     "label": "Traffic area",
      *     "disable_inarray_validator": false,
-     *     "service_name": "\Common\Service\Data\TrafficArea"
+     *     "service_name": "Common\Service\Data\TrafficArea"
      * })
      * @Form\Type("DynamicSelect")
      */


### PR DESCRIPTION
## Description

Removes the prepending slash from the `service_name` for `GenerateContinuationDetails`.

Related issue: https://dvsa.atlassian.net/browse/VOL-4864

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?