### PR TITLE
fix: fix type error in `AbstractInputSearch` when `this->messages` is empty

### DIFF
--- a/Common/src/Common/Form/Elements/Types/AbstractInputSearch.php
+++ b/Common/src/Common/Form/Elements/Types/AbstractInputSearch.php
@@ -28,7 +28,7 @@ abstract class AbstractInputSearch extends Fieldset
 
     public function getMessages(?string $elementName = null): array
     {
-        return is_array($this->messages) ? current($this->messages) : [];
+        return current($this->messages) ?: [];
     }
 
     abstract protected function addHint();

--- a/test/Common/src/Common/Form/Elements/Types/AbstractInputSearchTest.php
+++ b/test/Common/src/Common/Form/Elements/Types/AbstractInputSearchTest.php
@@ -9,6 +9,32 @@ use PHPUnit\Framework\TestCase;
 
 class AbstractInputSearchTest extends TestCase
 {
+    public function testEmptyMessages(): void
+    {
+        $sut = new class extends AbstractInputSearch {
+            public $hint;
+            public $input;
+            public $submit;
+
+            protected function addHint()
+            {
+                $this->hint = 'hint_is_set';
+            }
+
+            protected function addInput()
+            {
+                $this->input = 'input_is_set';
+            }
+
+            protected function addSubmit()
+            {
+                $this->submit = 'submit_is_set';
+            }
+        };
+
+        $messages = $sut->getMessages();
+        $this->assertEmpty($messages);
+    }
 
     public function testSetAndGetMessages()
     {


### PR DESCRIPTION
## Description

When `$this->messages` were empty, `current($this->messages)` returns `false`, contrary to the return type.

Related issue: https://dvsa.atlassian.net/browse/VOL-4870

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
