### PR TITLE
Add optional select form element

### DIFF
--- a/Common/src/Common/Controller/Lva/AbstractAddressesController.php
+++ b/Common/src/Common/Controller/Lva/AbstractAddressesController.php
@@ -100,18 +100,6 @@ abstract class AbstractAddressesController extends AbstractController
             )
             ->setData($formData);
 
-        $searchPostcodeInputFilter = $form->getInputFilter()->get('correspondence_address')->get('searchPostcode');
-        foreach ($searchPostcodeInputFilter->getInputs() as $input) {
-            $input->setRequired(false);
-            $input->setAllowEmpty(true);
-        }
-
-        $searchPostcodeInputFilter = $form->getInputFilter()->get('establishment_address')->get('searchPostcode');
-        foreach ($searchPostcodeInputFilter->getInputs() as $input) {
-            $input->setRequired(false);
-            $input->setAllowEmpty(true);
-        }
-
         $this->alterFormForLva($form);
 
         $hasProcessed = $this->formHelper->processAddressLookupForm($form, $request);

--- a/Common/src/Common/Form/Element/OptionalSelect.php
+++ b/Common/src/Common/Form/Element/OptionalSelect.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Common\Form\Element;
+
+use Laminas\Form\Element\Select;
+
+/**
+ * This class exists as the default Select class is marked as required by default.
+ */
+class OptionalSelect extends Select
+{
+    public function getInputSpecification(): array
+    {
+        $spec = parent::getInputSpecification();
+
+        $spec['required'] = false;
+
+        return $spec;
+    }
+}

--- a/Common/src/Common/Form/Elements/Types/PostcodeSearch.php
+++ b/Common/src/Common/Form/Elements/Types/PostcodeSearch.php
@@ -7,6 +7,7 @@
  */
 namespace Common\Form\Elements\Types;
 
+use Common\Form\Element\OptionalSelect;
 use Laminas\Form\Fieldset;
 use Laminas\Form\Element\Text;
 use Laminas\Form\Element\Button;
@@ -72,7 +73,7 @@ class PostcodeSearch extends Fieldset
 
         $selectAddressId = 'selectAddress' . self::$count;
 
-        $selectAddress = new Select(
+        $selectAddress = new OptionalSelect(
             'addresses',
             array(
                 'label' => 'postcode.select_address.label',

--- a/Common/src/Common/FormService/Form/Lva/OperatingCentre/CommonOperatingCentre.php
+++ b/Common/src/Common/FormService/Form/Lva/OperatingCentre/CommonOperatingCentre.php
@@ -76,12 +76,6 @@ class CommonOperatingCentre
         }
 
         $form->get('address')->get('postcode')->setOption('shouldEscapeMessages', false);
-
-        $searchPostcodeInputFilter = $form->getInputFilter()->get('address')->get('searchPostcode');
-        foreach ($searchPostcodeInputFilter->getInputs() as $input) {
-            $input->setRequired(false);
-            $input->setAllowEmpty(true);
-        }
     }
 
     /**

--- a/test/Common/src/Common/Form/Element/OptionalSelect.php
+++ b/test/Common/src/Common/Form/Element/OptionalSelect.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace CommonTest\Common\Form\Element;
+
+use PHPUnit\Framework\TestCase;
+
+class OptionalSelect extends TestCase
+{
+    public function testSelectNotRequired()
+    {
+        $select = new \Common\Form\Element\OptionalSelect();
+
+        $this->assertFalse($select->getInputSpecification()['required']);
+    }
+}


### PR DESCRIPTION
## Description

The Laminas form `Select` to mark as not required by default. This PR extends the Laminas form `Select` element and marks it as not required by default - this is weird decision by Laminas, the other elements are in fact _not_ required by default. This element is useful for postcode lookups where they are form elements but can be entered manually.

Alternative would be setting `setRequired` each time the "Search postcode" is used, this seemed more appropriate.

Related issue: https://dvsa.atlassian.net/browse/VOL-4875 & https://dvsa.atlassian.net/browse/VOL-4855

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
