### PR TITLE
fix: keep `SearchPostcode` fieldset at the top of the `Address` fieldset

### DIFF
--- a/Common/src/Common/Form/Model/Fieldset/Address.php
+++ b/Common/src/Common/Form/Model/Fieldset/Address.php
@@ -32,6 +32,7 @@ class Address
      * })
      * @Form\Required(false)
      * @Form\Type("Common\Form\Elements\Types\PostcodeSearch")
+     * @Form\Flags({"priority": 100})
      */
     public $searchPostcode = null;
 

--- a/Common/src/Common/Form/Model/Fieldset/AddressOptional.php
+++ b/Common/src/Common/Form/Model/Fieldset/AddressOptional.php
@@ -32,6 +32,7 @@ class AddressOptional
      * })
      * @Form\Required(false)
      * @Form\Type("Common\Form\Elements\Types\PostcodeSearch")
+     * @Form\Flags({"priority": 100})
      */
     public $searchPostcode = null;
 


### PR DESCRIPTION
## Description

Keep `SearchPostcode` fieldset at the top of the `Address` fieldset.

Elements are injected first into a `PriorityList`, then fieldsets. Without priority, the sequential insert order is used, this was putting the `SearchPostcode` fieldset _after_ the address elements instead of at the top of the parent fieldset.

Ticket: https://dvsa.atlassian.net/browse/VOL-4887

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
