### PR TITLE
fix: add `create_empty_option` to date fields that can be empty

### DIFF
--- a/Common/src/Common/Service/Qa/Custom/CertRoadworthiness/MotExpiryDateFieldsetPopulator.php
+++ b/Common/src/Common/Service/Qa/Custom/CertRoadworthiness/MotExpiryDateFieldsetPopulator.php
@@ -68,7 +68,8 @@ class MotExpiryDateFieldsetPopulator implements FieldsetPopulatorInterface
                     'dateMustBeBefore' => $dateWithThresholdOptions['dateThreshold'],
                     'invalidDateKey' => 'qanda.certificate-of-roadworthiness.mot-expiry-date.error.date-invalid',
                     'dateInPastKey' => 'qanda.certificate-of-roadworthiness.mot-expiry-date.error.date-in-past',
-                    'dateNotBeforeKey' => 'qanda.certificate-of-roadworthiness.mot-expiry-date.error.date-too-far'
+                    'dateNotBeforeKey' => 'qanda.certificate-of-roadworthiness.mot-expiry-date.error.date-too-far',
+                    'create_empty_option' => true,
                 ],
                 'attributes' => [
                     'value' => $dateWithThresholdOptions['date']['value']

--- a/Common/src/Common/Service/Qa/Custom/EcmtRemoval/PermitStartDateFieldsetPopulator.php
+++ b/Common/src/Common/Service/Qa/Custom/EcmtRemoval/PermitStartDateFieldsetPopulator.php
@@ -55,7 +55,8 @@ class PermitStartDateFieldsetPopulator implements FieldsetPopulatorInterface
                     'dateMustBeBefore' => $options['dateThreshold'],
                     'invalidDateKey' => 'qanda.ecmt-removal.permit-start-date.error.date-invalid',
                     'dateInPastKey' => 'qanda.ecmt-removal.permit-start-date.error.date-in-past',
-                    'dateNotBeforeKey' => 'qanda.ecmt-removal.permit-start-date.error.date-too-far'
+                    'dateNotBeforeKey' => 'qanda.ecmt-removal.permit-start-date.error.date-too-far',
+                    'create_empty_option' => true,
                 ],
                 'attributes' => [
                     'value' => $options['date']['value']


### PR DESCRIPTION
## Description

Add the new `create_empty_option` (introduced in Laminas v3) to the `DateSelect` field otherwise you get todays date.

Related issue: https://dvsa.atlassian.net/browse/VOL-4903

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
