### PR TITLE
fix: add priority to forms to order elements/fieldsets better

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceHistoryData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceHistoryData.php
@@ -22,6 +22,7 @@ class LicenceHistoryData
      * @Form\Validator("Common\Form\Elements\Validators\LicenceHistoryLicenceValidator",
      *     options={"table": "prevHasLicence-table"}
      *)
+     * @Form\Flags({"priority": -10})
      */
     public $prevHasLicence = null;
 
@@ -32,6 +33,7 @@ class LicenceHistoryData
      *      "id":"prevHasLicence",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -20})
      */
     public $prevHasLicenceTable = null;
 
@@ -48,6 +50,7 @@ class LicenceHistoryData
      * @Form\Validator("Common\Form\Elements\Validators\LicenceHistoryLicenceValidator",
      *     options={"table": "prevHadLicence-table"}
      *)
+     * @Form\Flags({"priority": -30})
      */
     public $prevHadLicence = null;
 
@@ -58,6 +61,7 @@ class LicenceHistoryData
      *      "id":"prevHadLicence",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -40})
      */
     public $prevHadLicenceTable = null;
 
@@ -74,6 +78,7 @@ class LicenceHistoryData
      * @Form\Validator("Common\Form\Elements\Validators\LicenceHistoryLicenceValidator",
      *     options={"table": "prevBeenDisqualifiedTc-table"}
      *)
+     * @Form\Flags({"priority": -50})
      */
     public $prevBeenDisqualifiedTc = null;
 
@@ -84,6 +89,7 @@ class LicenceHistoryData
      *      "id":"prevBeenDisqualifiedTc",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -60})
      */
     public $prevBeenDisqualifiedTcTable = null;
 }

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceHistoryEu.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceHistoryEu.php
@@ -22,6 +22,7 @@ class LicenceHistoryEu
      * @Form\Validator("Common\Form\Elements\Validators\LicenceHistoryLicenceValidator",
      *     options={"table": "prevBeenRefused-table"}
      *)
+     * @Form\Flags({"priority": -10})
      */
     public $prevBeenRefused = null;
 
@@ -32,6 +33,7 @@ class LicenceHistoryEu
      *      "id":"prevBeenRefused",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -20})
      */
     public $prevBeenRefusedTable = null;
 
@@ -48,6 +50,7 @@ class LicenceHistoryEu
      * @Form\Validator("Common\Form\Elements\Validators\LicenceHistoryLicenceValidator",
      *     options={"table":"prevBeenRevoked-table"}
      *)
+     * @Form\Flags({"priority": -30})
      */
     public $prevBeenRevoked = null;
 
@@ -58,6 +61,7 @@ class LicenceHistoryEu
      *      "id":"prevBeenRevoked",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -40})
      */
     public $prevBeenRevokedTable = null;
 }

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/TransportManager/PreviousHistory.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/TransportManager/PreviousHistory.php
@@ -25,6 +25,7 @@ class PreviousHistory
      *     }
      * )
      * @Form\Type("Radio")
+     * @Form\Flags({"priority": -10})
      */
     public $hasConvictions = null;
 
@@ -35,6 +36,7 @@ class PreviousHistory
      *      "id":"previousConvictions",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -20})
      */
     public $convictions = null;
 
@@ -53,6 +55,7 @@ class PreviousHistory
      *     }
      * )
      * @Form\Type("Radio")
+     * @Form\Flags({"priority": -30})
      */
     public $hasPreviousLicences = null;
 
@@ -63,6 +66,7 @@ class PreviousHistory
      *      "id":"previousLicences",
      *      "class": "help__text help__text--removePadding"
      * })
+     * @Form\Flags({"priority": -40})
      */
     public $previousLicences = null;
 }

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/TransportManager/Responsibilities.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/TransportManager/Responsibilities.php
@@ -30,6 +30,7 @@ class Responsibilities
      * })
      * @Form\Type("DynamicRadio")
      * @Form\Validator("Laminas\Validator\NotEmpty")
+     * @Form\Flags({"priority": -10})
      */
     public $tmType = null;
 
@@ -42,6 +43,7 @@ class Responsibilities
      * @Form\Required(true)
      * @Form\Attributes({"id":"","placeholder":"", "required":false})
      * @Form\Type("DynamicSelect")
+     * @Form\Flags({"priority": -20})
      */
     public $tmApplicationStatus = null;
 
@@ -55,6 +57,7 @@ class Responsibilities
      *     "hint-class" : "govuk-radios__conditional govuk-body hint hint__below hint__black hintNoOwner",
      * })
      * @Form\Type("Radio")
+     * @Form\Flags({"priority": -30})
      */
     public $isOwner = null;
 
@@ -62,12 +65,14 @@ class Responsibilities
      * @Form\Name("hoursOfWeek")
      * @Form\ComposedObject("Common\Form\Model\Fieldset\HoursOfWeekRequired")
      * @Form\Attributes({"id":"hoursOfWeek"})
+     * @Form\Flags({"priority": -40})
      */
     public $hoursOfWeek = null;
 
     /**
      * @Form\Name("otherLicencesFieldset")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\TransportManager\OtherLicencesFieldset")
+     * @Form\Flags({"priority": -50})
      */
     public $otherLicencesFieldset = null;
 
@@ -92,12 +97,14 @@ class Responsibilities
      *          "max":4000
      *      }
      * )
+     * @Form\Flags({"priority": -60})
      */
     public $additionalInformation;
 
     /**
      * @Form\Attributes({"id":"file", "class": "file-upload"})
      * @Form\ComposedObject("\Common\Form\Model\Fieldset\MultipleFileUpload")
+     * @Form\Flags({"priority": -70})
      */
     public $file = null;
 }

--- a/Common/src/Common/Form/Model/Form/Lva/TransportManagerDetails.php
+++ b/Common/src/Common/Form/Model/Form/Lva/TransportManagerDetails.php
@@ -18,6 +18,7 @@ class TransportManagerDetails
     /**
      * @Form\Name("details")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\TransportManager\Details")
+     * @Form\Flags({"priority": -10})
      */
     public $details = null;
 
@@ -31,6 +32,7 @@ class TransportManagerDetails
      *         "id":"homeAddress"
      *     }
      * })
+     * @Form\Flags({"priority": -20})
      */
     public $homeAddress = null;
 
@@ -40,6 +42,7 @@ class TransportManagerDetails
      * @Form\Options({
      *     "label":"lva-tm-details-details-workAddress"
      * })
+     * @Form\Flags({"priority": -30})
      */
     public $workAddress = null;
 
@@ -47,18 +50,21 @@ class TransportManagerDetails
      * @Form\Name("responsibilities")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\TransportManager\Responsibilities")
      * @Form\Options({"label":"lva-tm-details-details-responsibilities"})
+     * @Form\Flags({"priority": -40})
      */
     public $responsibilities = null;
 
     /**
      * @Form\Name("otherEmployments")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\TransportManager\OtherEmployments")
+     * @Form\Flags({"priority": -50})
      */
     public $otherEmployments = null;
 
     /**
      * @Form\Name("previousHistory")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\TransportManager\PreviousHistory")
+     * @Form\Flags({"priority": -60})
      */
     public $previousHistory = null;
 
@@ -66,6 +72,7 @@ class TransportManagerDetails
      * @Form\Name("form-actions")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\TmDetailsFormActions")
      * @Form\Attributes({"class":"govuk-button-group"})
+     * @Form\Flags({"priority": -70})
      */
     public $formActions = null;
 }


### PR DESCRIPTION
## Description

If a fieldset contains a mix of fieldsets and elements the fieldsets are always processed afterwards - resulting in the form being ordered differently - elements first, followed by any fieldsets.

Related issue: https://dvsa.atlassian.net/browse/VOL-4896 & https://dvsa.atlassian.net/browse/VOL-4894

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
