### PR TITLE
feat: Message list split in to two columns

### DIFF
--- a/Common/config/formatter-plugins.config.php
+++ b/Common/config/formatter-plugins.config.php
@@ -40,6 +40,8 @@ use Common\Service\Table\Formatter\EventHistoryDescription;
 use Common\Service\Table\Formatter\EventHistoryUser;
 use Common\Service\Table\Formatter\ExternalConversationLink;
 use Common\Service\Table\Formatter\ExternalConversationLinkFactory;
+use Common\Service\Table\Formatter\ExternalConversationStatus;
+use Common\Service\Table\Formatter\ExternalConversationStatusFactory;
 use Common\Service\Table\Formatter\FeatureToggleEditLink;
 use Common\Service\Table\Formatter\FeeAmount;
 use Common\Service\Table\Formatter\FeeAmountSum;
@@ -334,6 +336,7 @@ return [
         EventHistoryDescription::class => EventHistoryDescriptionFactory::class,
         EventHistoryUser::class => EventHistoryUserFactory::class,
         ExternalConversationLink::class => ExternalConversationLinkFactory::class,
+        ExternalConversationStatus::class => ExternalConversationStatusFactory::class,
         FeatureToggleEditLink::class => FeatureToggleEditLinkFactory::class,
         FeeAmountSum::class => FeeAmountSumFactory::class,
         FeeIdUrl::class => FeeIdUrlFactory::class,

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
@@ -35,29 +35,15 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
         ];
 
         $statusCSS = '';
-
-        switch ($row['userContextStatus']) {
-            case "NEW_MESSAGE":
-                $statusCSS = 'govuk-!-font-weight-bold';
-                $tagColor = 'govuk-tag--red';
-                break;
-            case "OPEN":
-                $tagColor = 'govuk-tag--blue';
-                break;
-            case "CLOSED":
-                $tagColor = 'govuk-tag--grey';
-                break;
-            default:
-                $tagColor = 'govuk-tag--green';
-                break;
+        if ($row['userContextStatus'] === "NEW_MESSAGE") {
+            $statusCSS = 'govuk-!-font-weight-bold';
         }
 
-        $rows = '<a class="' . 'govuk-body govuk-link govuk-!-padding-right-1 ' . $statusCSS . '" href="%s">%s: %s</a>
-                <strong class="govuk-tag ' . $tagColor . '">
-                    %s
-                </strong>
-                <br>';
-        $rows = $rows . '<p class="govuk-body govuk-!-margin-1">%s</p>';
+        $rows = '
+            <a class="' . 'govuk-body govuk-link govuk-!-padding-right-1 %s" href="%s">%s: %s</a>
+            <br>
+            <p class="govuk-body govuk-!-margin-1">%s</p>
+        ';
 
         $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $row["createdOn"]);
         $dtOutput = $latestMessageCreatedOn->format('l j F Y \a\t H:ia');
@@ -71,10 +57,10 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
         return vsprintf(
             $rows,
             [
+                $statusCSS,
                 $this->urlHelper->fromRoute($route, $params),
                 $idMatrix,
                 $row["subject"],
-                str_replace('_', ' ', $row['userContextStatus']),
                 $dtOutput,
             ],
         );

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
@@ -40,7 +40,7 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
         }
 
         $rows = '
-            <a class="' . 'govuk-body govuk-link govuk-!-padding-right-1 %s" href="%s">%s: %s</a>
+            <a class="govuk-body govuk-link govuk-!-padding-right-1 %s" href="%s">%s: %s</a>
             <br>
             <p class="govuk-body govuk-!-margin-1">%s</p>
         ';

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationStatus.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationStatus.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Table\Formatter;
+
+class ExternalConversationStatus implements FormatterPluginManagerInterface
+{
+    /**
+     * status
+     *
+     * @param array $row Row data
+     * @param array $column Column data
+     *
+     * @return     string
+     * @inheritdoc
+     */
+    public function format($row, $column = null): string
+    {
+        switch ($row['userContextStatus']) {
+            case "NEW_MESSAGE":
+                $tagColor = 'govuk-tag--red';
+                break;
+            case "OPEN":
+                $tagColor = 'govuk-tag--blue';
+                break;
+            case "CLOSED":
+                $tagColor = 'govuk-tag--grey';
+                break;
+            default:
+                $tagColor = 'govuk-tag--green';
+                break;
+        }
+
+        return sprintf(
+            '<strong class="govuk-tag %s">%s</strong>',
+            $tagColor,
+            str_replace('_', ' ', $row['userContextStatus']),
+        );
+    }
+}

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationStatusFactory.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationStatusFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Service\Table\Formatter;
+
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
+
+class ExternalConversationStatusFactory implements FactoryInterface
+{
+    /**
+     * @param  ContainerInterface $container
+     * @param  $requestedName
+     * @param  array|null         $options
+     * @return ExternalConversationStatus
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new ExternalConversationStatus();
+    }
+}


### PR DESCRIPTION
## Description

External message list should be split in to two columns with status in the right column.

Related issue: [VOL-4805](https://dvsa.atlassian.net/browse/VOL-4805)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
