### PR TITLE
fix: remove cache of element in `FileUploadHelperService`

### DIFF
--- a/Common/src/Common/Service/Helper/FileUploadHelperService.php
+++ b/Common/src/Common/Service/Helper/FileUploadHelperService.php
@@ -236,31 +236,6 @@ class FileUploadHelperService extends AbstractHelperService
     }
 
     /**
-     * Get element
-     *
-     * @return ElementInterface
-     */
-    public function getElement()
-    {
-        $this->element = $this->findElement($this->getForm(), $this->getSelector());
-
-        return $this->element;
-    }
-
-    /**
-     * Set element
-     *
-     * @param ElementInterface $element Element
-     *
-     * @return $this
-     */
-    public function setElement($element)
-    {
-        $this->element = $element;
-        return $this;
-    }
-
-    /**
      * Process file uploads/deletions and list population
      *
      * @return boolean
@@ -304,7 +279,7 @@ class FileUploadHelperService extends AbstractHelperService
 
         $files = call_user_func($callback);
 
-        $element = $this->getElement();
+        $element = $this->findElement($this->getForm(), $this->getSelector());
 
         $element->get('list')->setFiles($files, $url);
 
@@ -478,9 +453,11 @@ class FileUploadHelperService extends AbstractHelperService
             return false;
         }
 
-        $element = $this->getElement()->get('list');
+        $element = $this->findElement($this->getForm(), $this->getSelector());
 
-        foreach ($element->getFieldsets() as $listFieldset) {
+        $list = $element->get('list');
+
+        foreach ($list->getFieldsets() as $listFieldset) {
             $name = $listFieldset->getName();
 
             if (isset($postData['list'][$name]['remove'])
@@ -491,7 +468,7 @@ class FileUploadHelperService extends AbstractHelperService
                 );
 
                 if ($success === true) {
-                    $element->remove($name);
+                    $list->remove($name);
                     $this->decrementCount();
                 }
 
@@ -563,7 +540,7 @@ class FileUploadHelperService extends AbstractHelperService
      *
      * @return \Laminas\Form\ElementInterface
      */
-    private function findElement($form, $selector)
+    public function findElement($form, $selector)
     {
         if (strstr($selector, '->')) {
             list($element, $selector) = explode('->', $selector, 2);

--- a/Common/src/Common/Service/Helper/FileUploadHelperService.php
+++ b/Common/src/Common/Service/Helper/FileUploadHelperService.php
@@ -242,9 +242,7 @@ class FileUploadHelperService extends AbstractHelperService
      */
     public function getElement()
     {
-        if ($this->element === null) {
-            $this->element = $this->findElement($this->getForm(), $this->getSelector());
-        }
+        $this->element = $this->findElement($this->getForm(), $this->getSelector());
 
         return $this->element;
     }

--- a/test/Common/src/Common/Service/Helper/FileUploadHelperServiceTest.php
+++ b/test/Common/src/Common/Service/Helper/FileUploadHelperServiceTest.php
@@ -99,32 +99,6 @@ class FileUploadHelperServiceTest extends MockeryTestCase
         );
     }
 
-    public function testSetGetElement()
-    {
-        $this->assertEquals(
-            'fakeElement',
-            $this->sut->setElement('fakeElement')->getElement()
-        );
-    }
-
-    public function testGetElementFromFormAndSelector()
-    {
-        $fieldset = m::mock('Laminas\Form\Fieldset');
-        $element = m::mock(ElementInterface::class);
-
-        $this->mockForm->shouldReceive('get')
-            ->with('foo')
-            ->andReturn($fieldset);
-
-        $fieldset->shouldReceive('get')
-            ->with('bar')
-            ->andReturn($element);
-
-        $this->sut->setSelector('foo->bar');
-
-        $this->assertEquals($element, $this->sut->getElement());
-    }
-
     public function testProcessWithGetRequestAndNoLoadCallback()
     {
         $this->mockRequest->shouldReceive('isPost')->andReturn(false);
@@ -579,7 +553,6 @@ class FileUploadHelperServiceTest extends MockeryTestCase
             ->with('list')
             ->andReturn($listElement);
 
-        $this->sut->setElement($element);
         $this->sut->setSelector('my-file');
         $this->sut->setDeleteCallback(
             function ($id) {
@@ -598,8 +571,12 @@ class FileUploadHelperServiceTest extends MockeryTestCase
         $this->mockForm
             ->shouldReceive('get')
             ->with('my-hidden-field')
-            ->andReturn($fileCountfield)
-            ->getMock();
+            ->andReturn($fileCountfield);
+
+        $this->mockForm
+            ->shouldReceive('get')
+            ->with('my-file')
+            ->andReturn($element);
 
         $this->assertEquals(true, $this->sut->process());
     }
@@ -629,17 +606,18 @@ class FileUploadHelperServiceTest extends MockeryTestCase
             ->shouldReceive('remove')
             ->with('file1');
 
-        $element = m::mock('\stdClass');
+        $element = m::mock(ElementInterface::class);
         $element->shouldReceive('get')
             ->with('list')
             ->andReturn($listElement);
 
-        $this->sut->setElement($element);
         $this->sut->setSelector('my-file');
         $this->sut->setDeleteCallback(
             function () {
             }
         );
+
+        $this->mockForm->shouldReceive('get')->andReturn($element);
 
         $this->assertEquals(false, $this->sut->process());
     }


### PR DESCRIPTION
## Description

A previous commit moved this service to dependency injection rather than initialising each `process` call. This meant the previously set `$this->element` would remain the same for any calls to this service as each call would re-use the same object.

Related issue: https://dvsa.atlassian.net/browse/VOL-4845

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
