### PR TITLE
fix: consolidate `Navigation` and `navigation`

### DIFF
--- a/Common/config/module.config.php
+++ b/Common/config/module.config.php
@@ -334,8 +334,6 @@ return [
             // Added in a true Laminas Framework V2 compatible factory for TableBuilder, eventually to replace Table above.
             'Common\Service\Table\TableBuilderFactory' => 'Common\Service\Table\TableBuilderFactory',
             'ServiceApiResolver' => 'Common\Service\Api\ResolverFactory',
-            'navigation' => 'Laminas\Navigation\Service\DefaultNavigationFactory',
-            'Navigation' => 'Laminas\Navigation\Service\DefaultNavigationFactory',
             'SectionService' => '\Common\Controller\Service\SectionServiceFactory',
             'FormAnnotationBuilder' => '\Common\Service\FormAnnotationBuilderFactory',
             'Common\Service\Data\PluginManager' => Common\Service\Data\PluginManagerFactory::class,

--- a/Common/src/Common/Controller/Plugin/ElasticSearchFactory.php
+++ b/Common/src/Common/Controller/Plugin/ElasticSearchFactory.php
@@ -15,7 +15,7 @@ class ElasticSearchFactory implements FactoryInterface
 
         $searchService = $container->get('DataServiceManager')->get(Search::class);
         $searchTypeService = $container->get('DataServiceManager')->get(SearchType::class);
-        $navigation = $container->get('Navigation');
+        $navigation = $container->get('navigation');
 
         $plugin->setSearchService($searchService);
         $plugin->setSearchTypeService($searchTypeService);


### PR DESCRIPTION
## Description

The projects were using a mix of `Navigation` and `navigation` resulting in two different objects - this caused issues with navigation as two different objects were being mutated and used.

I went with `navigation` even though it was a larger refactor due to that being the alias that is registered in the upstream package: https://github.com/laminas/laminas-navigation/blob/2f39ab2f929d23da89bbb4401efdccb6e72eaf68/src/ConfigProvider.php#L33.

Related issue:  https://dvsa.atlassian.net/browse/VOL-4900 & https://dvsa.atlassian.net/browse/VOL-4915

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
