### PR TITLE
fix: lowercasing formdatetimeselect. Custom helper not being used

### DIFF
--- a/Common/config/module.config.php
+++ b/Common/config/module.config.php
@@ -487,7 +487,7 @@ return [
             'formRadioVertical' => \Common\Form\View\Helper\FormRadioVertical::class,
             'form' => 'Common\Form\View\Helper\Form',
             \Common\Form\View\Helper\FormCollection::class => Common\Form\View\Helper\FormCollection::class,
-            'formDateTimeSelect' => 'Common\Form\View\Helper\FormDateTimeSelect',
+            'formdatetimeselect' => 'Common\Form\View\Helper\FormDateTimeSelect',
             'formDateSelect' => \Common\Form\View\Helper\FormDateSelect::class,
             FormInputSearch::class => FormInputSearch::class,
             'formPlainText' => 'Common\Form\View\Helper\FormPlainText',


### PR DESCRIPTION
## Description

lowercasing entry in module.config.php, now custom helper is being used. Fixes rendering of some elements to format defined in the pattern annotation

Related issue: [VOL-4931](https://dvsa.atlassian.net/browse/VOL-4932)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
