### PR TITLE
fix: update `MAX_LENGTH` to `string` to fix type error

### DIFF
--- a/Common/src/Common/Form/Elements/Custom/EcmtNoOfPermitsElement.php
+++ b/Common/src/Common/Form/Elements/Custom/EcmtNoOfPermitsElement.php
@@ -12,7 +12,7 @@ use Laminas\Validator\StringLength;
 class EcmtNoOfPermitsElement extends Text implements InputProviderInterface
 {
     const GENERIC_ERROR_KEY = 'qanda.ecmt.number-of-permits.error.enter-permits-needed';
-    const MAX_LENGTH = 4;
+    const MAX_LENGTH = '4';
 
     protected $attributes = [
         'maxLength' => self::MAX_LENGTH

--- a/Common/src/Common/Service/Qa/Custom/Bilateral/NoOfPermitsElement.php
+++ b/Common/src/Common/Service/Qa/Custom/Bilateral/NoOfPermitsElement.php
@@ -11,7 +11,7 @@ use Laminas\Validator\StringLength;
 
 class NoOfPermitsElement extends Text implements InputProviderInterface
 {
-    const MAX_LENGTH = 4;
+    const MAX_LENGTH = '4';
     const ERROR_KEY = 'qanda.bilaterals.number-of-permits.error.enter-permits-required';
 
     protected $attributes = [


### PR DESCRIPTION
## Description

This value is passed to: `\Laminas\Form\View\Helper\AbstractHelper::translateHtmlAttributeValue` which is now typed to a `string`.

Related issue: https://dvsa.atlassian.net/browse/VOL-4935

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
