### PR TITLE
fix: fix undefined `formHelper` variable

### DIFF
--- a/Common/src/Common/Controller/Lva/AbstractCommunityLicencesController.php
+++ b/Common/src/Common/Controller/Lva/AbstractCommunityLicencesController.php
@@ -505,7 +505,7 @@ abstract class AbstractCommunityLicencesController extends AbstractController
         $ids = explode(',', $this->params('child_id'));
         if (!$request->isPost()) {
             $form = $this->formHelper->createForm('Lva\CommunityLicencesAnnul');
-            $formHelper->setFormActionFromRequest($form, $this->getRequest());
+            $this->formHelper->setFormActionFromRequest($form, $this->getRequest());
 
             $view = new ViewModel(['form' => $form]);
             $view->setTemplate('partials/form');


### PR DESCRIPTION
## Description

Fixes the undefined variable `$formHelper` - this is now a class property.

Related issue: https://dvsa.atlassian.net/browse/VOL-4988

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
