### PR TITLE
fix: add `FormCollection` overwrite to service manager

### DIFF
--- a/Common/config/module.config.php
+++ b/Common/config/module.config.php
@@ -576,6 +576,7 @@ return [
             'formrow' => \Common\Form\View\Helper\FormRow::class,
             'formcollection' => \Common\Form\View\Helper\FormCollection::class,
             'formCollection' => Common\Form\View\Helper\FormCollection::class,
+            'FormCollection' => Common\Form\View\Helper\FormCollection::class,
             'form_collection' => \Common\Form\View\Helper\FormCollection::class,
             'formRow' => \Common\Form\View\Helper\FormRow::class,
             'formelement' => \Common\Form\View\Helper\FormElement::class,


### PR DESCRIPTION
## Description

As L3 made the Service Manager case sensitive, `->get('FormCollection')` would return the Laminas class rather than our overwritten class.

Related issue: https://dvsa.atlassian.net/browse/VOL-5055

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
