### PR TITLE
fix: add `isSelf` to `Permission` service

### DIFF
--- a/Common/src/Common/Rbac/Service/Permission.php
+++ b/Common/src/Common/Rbac/Service/Permission.php
@@ -29,4 +29,17 @@ class Permission
     {
         return $this->authService->isGranted($permission, $context);
     }
+
+    public function isSelf(string $userId): bool
+    {
+        $userData = $this->authService->getIdentity()->getUserData();
+
+        $currentUserId = $userData['id'] ?? null;
+
+        if ($currentUserId === null) {
+            return false;
+        }
+
+        return strval($currentUserId) === $userId;
+    }
 }

--- a/test/Common/src/Common/Rbac/Service/PermissionTest.php
+++ b/test/Common/src/Common/Rbac/Service/PermissionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CommonTest\Rbac;
 
 use Common\Rbac\Service\Permission;
+use Common\Rbac\User;
 use Common\RefData;
 use LmcRbacMvc\Service\AuthorizationService;
 use Mockery as m;
@@ -19,6 +20,27 @@ class PermissionTest extends MockeryTestCase
     {
         $this->authService = m::mock(AuthorizationService::class);
         $this->sut = new Permission($this->authService);
+    }
+
+    public function testIsSelf(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserData')->willReturn(['id' => 1]);
+
+        $this->authService->expects('getIdentity')->twice()->andReturn($user);
+
+        $this->assertTrue($this->sut->isSelf('1'));
+        $this->assertFalse($this->sut->isSelf('2'));
+    }
+
+    public function testIsSelfWithIncompleteUserData(): void
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getUserData')->willReturn(['something-else' => 1]);
+
+        $this->authService->expects('getIdentity')->andReturn($user);
+
+        $this->assertFalse($this->sut->isSelf('1'));
     }
 
     public function testIsInternalUserButNotReadOnly(): void


### PR DESCRIPTION
## Description

Add `isSelf` to `Permission` service to provide a method to check if the user ID provided is the current logged in user.

Related issue: Regression from https://dvsa.atlassian.net/browse/VOL-5103

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
