### PR TITLE
feat: Message footer showing operator first read

### DIFF
--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -66,7 +66,7 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
             </div>
         ';
 
-        $firstReadyBy = $this->getFirstReadBy($row);
+        $firstReadBy = $this->getFirstReadBy($row);
 
         return vsprintf(
             $rowTemplate,
@@ -75,7 +75,7 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
                 $date,
                 nl2br($row['messagingContent']['text']),
                 $fileList ?: '',
-                $firstReadyBy,
+                $firstReadBy,
             ],
         );
     }

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -60,10 +60,13 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
                     <div class="govuk-summary-card__content">
                         <p class="govuk-body">%s</p>
                         %s
+                        %s
                     </div>
                 </div>
             </div>
         ';
+
+        $firstReadyBy = $this->getFirstReadBy($row);
 
         return vsprintf(
             $rowTemplate,
@@ -72,6 +75,7 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
                 $date,
                 nl2br($row['messagingContent']['text']),
                 $fileList ?: '',
+                $firstReadyBy,
             ],
         );
     }
@@ -86,5 +90,30 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
         $suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
 
         return round(1024 ** ($base - floor($base)), 2) . $suffixes[floor($base)];
+    }
+
+    public function getFirstReadBy(array $row): string
+    {
+        if (count($row['userMessageReads']) === 0) {
+            return '';
+        }
+
+        $firstRead = array_pop($row['userMessageReads']);
+        $firstReadOn = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $firstRead["createdOn"]);
+
+        if (isset($firstRead['user']['contactDetails']['person'])) {
+            $firstReadBy = $firstRead['user']['contactDetails']['person']['forename'] . ' ' .
+                           $firstRead['user']['contactDetails']['person']['familyName'];
+        } elseif (isset($firstRead['user']['contactDetails']['emailAddress'])) {
+            $firstReadBy = $firstRead['user']['contactDetails']['emailAddress'];
+        } else {
+            $firstReadBy = $firstRead['user']['loginId'];
+        }
+
+        return sprintf(
+            '<hr/><p><em>First read by %s on %s</em></p>',
+            $firstReadBy,
+            $firstReadOn->format('l j F Y \a\t H:ia'),
+        );
     }
 }


### PR DESCRIPTION
## Description

Add a footer to internal to show the first operator to read the message.

Related issue: [VOL-5082](https://dvsa.atlassian.net/browse/VOL-5082)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
