### PR TITLE
feat: Null check elastic search terms for filtering transport managers

### DIFF
--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/DeletedStatus.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/DeletedStatus.php
@@ -11,7 +11,7 @@ class DeletedStatus extends TermsAbstract
 
     public function getType(): string
     {
-        return self::TYPE_NULLCHECK;
+        return self::TYPE_BOOLEAN;
     }
 
     public function getOptionsKvp(): array

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/DeletedStatus.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/DeletedStatus.php
@@ -4,26 +4,9 @@ declare(strict_types=1);
 
 namespace Common\Data\Object\Search\Aggregations\Terms;
 
-/**
- * Licence Type filter class.
- *
- * @package Common\Data\Object\Search\Filter
- * @author Craig Reasbeck <craig.reasbeck@valtech.co.uk>
- */
 class DeletedStatus extends TermsAbstract
 {
-    /**
-     * The human readable title of this filter. This may also be used in the front-end (not sure yet).
-     *
-     * @var string
-     */
     protected $title = 'search.form.filter.deleted-status';
-
-    /**
-     * The actual name of the field to ask for filter information for.
-     *
-     * @var string
-     */
     protected $key = 'personDeleted';
 
     public function getType(): string

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/DeletedStatus.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/DeletedStatus.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Data\Object\Search\Aggregations\Terms;
+
+/**
+ * Licence Type filter class.
+ *
+ * @package Common\Data\Object\Search\Filter
+ * @author Craig Reasbeck <craig.reasbeck@valtech.co.uk>
+ */
+class DeletedStatus extends TermsAbstract
+{
+    /**
+     * The human readable title of this filter. This may also be used in the front-end (not sure yet).
+     *
+     * @var string
+     */
+    protected $title = 'search.form.filter.deleted-status';
+
+    /**
+     * The actual name of the field to ask for filter information for.
+     *
+     * @var string
+     */
+    protected $key = 'personDeleted';
+
+    public function getType(): string
+    {
+        return self::TYPE_NULLCHECK;
+    }
+
+    public function getOptionsKvp(): array
+    {
+        return $this->getOptions();
+    }
+
+    public function getOptions(): array
+    {
+        return [
+            '1' => 'Show deleted',
+            '0' => 'Hide deleted',
+        ];
+    }
+}

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/MergedStatus.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/MergedStatus.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Data\Object\Search\Aggregations\Terms;
+
+/**
+ * Licence Type filter class.
+ *
+ * @package Common\Data\Object\Search\Filter
+ * @author Craig Reasbeck <craig.reasbeck@valtech.co.uk>
+ */
+class MergedStatus extends TermsAbstract
+{
+    /**
+     * The human readable title of this filter. This may also be used in the front-end (not sure yet).
+     *
+     * @var string
+     */
+    protected $title = 'search.form.filter.merged-status';
+
+    /**
+     * The actual name of the field to ask for filter information for.
+     *
+     * @var string
+     */
+    protected $key = 'isMerged';
+
+    public function getType(): string
+    {
+        return self::TYPE_NULLCHECK;
+    }
+
+    public function getOptionsKvp(): array
+    {
+        return $this->getOptions();
+    }
+
+    public function getOptions(): array
+    {
+        return [
+            '1' => 'Show merged',
+            '0' => 'Hide merged',
+        ];
+    }
+}

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/MergedStatus.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/MergedStatus.php
@@ -11,7 +11,7 @@ class MergedStatus extends TermsAbstract
 
     public function getType(): string
     {
-        return self::TYPE_NULLCHECK;
+        return self::TYPE_BOOLEAN;
     }
 
     public function getOptionsKvp(): array

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/MergedStatus.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/MergedStatus.php
@@ -4,26 +4,9 @@ declare(strict_types=1);
 
 namespace Common\Data\Object\Search\Aggregations\Terms;
 
-/**
- * Licence Type filter class.
- *
- * @package Common\Data\Object\Search\Filter
- * @author Craig Reasbeck <craig.reasbeck@valtech.co.uk>
- */
 class MergedStatus extends TermsAbstract
 {
-    /**
-     * The human readable title of this filter. This may also be used in the front-end (not sure yet).
-     *
-     * @var string
-     */
     protected $title = 'search.form.filter.merged-status';
-
-    /**
-     * The actual name of the field to ask for filter information for.
-     *
-     * @var string
-     */
     protected $key = 'isMerged';
 
     public function getType(): string

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/TermsAbstract.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/TermsAbstract.php
@@ -18,6 +18,14 @@ abstract class TermsAbstract extends AggregationsAbstract
      */
     protected $options = [];
 
+    public const TYPE_DYNAMIC = 'DYNAMIC';
+    public const TYPE_NULLCHECK = 'NULLCHECK';
+
+    public function getType(): string
+    {
+        return self::TYPE_DYNAMIC;
+    }
+
     /**
      * @return array
      */

--- a/Common/src/Common/Data/Object/Search/Aggregations/Terms/TermsAbstract.php
+++ b/Common/src/Common/Data/Object/Search/Aggregations/Terms/TermsAbstract.php
@@ -19,7 +19,7 @@ abstract class TermsAbstract extends AggregationsAbstract
     protected $options = [];
 
     public const TYPE_DYNAMIC = 'DYNAMIC';
-    public const TYPE_NULLCHECK = 'NULLCHECK';
+    public const TYPE_BOOLEAN = 'BOOLEAN';
 
     public function getType(): string
     {

--- a/Common/src/Common/Data/Object/Search/People.php
+++ b/Common/src/Common/Data/Object/Search/People.php
@@ -57,6 +57,8 @@ class People extends InternalSearchAbstract
                 new Filter\FoundType(),
                 new Filter\FoundBy(),
                 new Filter\LicenceStatus(),
+                new Filter\DeletedStatus(),
+                new Filter\MergedStatus(),
             ];
         }
 


### PR DESCRIPTION
## Description

Allow filtering of transport managers by merged and deleted status.

Related issue: [VOL-3539](https://dvsa.atlassian.net/browse/VOL-3539)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
