### PR TITLE
fix: Reinstate casting attributes to string

### DIFF
--- a/Common/src/Common/Form/View/Helper/Extended/PrepareAttributesTrait.php
+++ b/Common/src/Common/Form/View/Helper/Extended/PrepareAttributesTrait.php
@@ -59,6 +59,11 @@ trait PrepareAttributesTrait
             if (isset($this->booleanAttributes[$attribute])) {
                 $attributes[$attribute] = $this->prepareBooleanAttributeValue($attribute, $value);
             }
+
+            $stringValue = (string) $value;
+
+            // Use the string key and value
+            $attributes[$key] = $stringValue;
         }
 
         return $attributes;

--- a/test/Common/src/Common/Form/View/Helper/Extended/FormRadioTest.php
+++ b/test/Common/src/Common/Form/View/Helper/Extended/FormRadioTest.php
@@ -139,7 +139,7 @@ class FormRadioTest extends MockeryTestCase
                 ],
                 'globalAttributes' => [],
                 'labelPosition' => null,
-                'expected' => '<div class="govuk-radios"><div class="govuk-radios__item"><input class="input_class govuk-radios__input" value="B" checked="checked" id="generated_id"><label class="label_class govuk-label govuk-radios__label" for="generated_id">default-translated-bbb</label><div class="hint_class govuk-hint govuk-radios__hint">default-translated-hint_text</div></div></div>'
+                'expected' => '<div class="govuk-radios"><div class="govuk-radios__item"><input class="input_class govuk-radios__input" value="B" checked="1" id="generated_id"><label class="label_class govuk-label govuk-radios__label" for="generated_id">default-translated-bbb</label><div class="hint_class govuk-hint govuk-radios__hint">default-translated-hint_text</div></div></div>'
             ],
         ];
     }

--- a/test/Common/src/Common/Form/View/Helper/Extended/PrepareAttributesTraitTest.php
+++ b/test/Common/src/Common/Form/View/Helper/Extended/PrepareAttributesTraitTest.php
@@ -20,9 +20,9 @@ class PrepareAttributesTraitTest extends MockeryTestCase
             'name' => 'data[unit_name]',
             'disabled' => 'off',
             'unit-attribute' => false,
-            'data-bool-Attr' => ['on' => 1],
+            'data-bool-attr' => 'on',
             'x-unit' => 'unit_x-unit_Value',
-            'DATA-unit' => 'unit_data-unit_Value',
+            'data-unit' => 'unit_data-unit_Value',
             'aria-unit' => 'unit_aria-unut_Value',
         ];
 
@@ -32,7 +32,7 @@ class PrepareAttributesTraitTest extends MockeryTestCase
                 'x-unit' => 'unit_x-unit_Value',
                 'data-unit' => 'unit_data-unit_Value',
                 'aria-unit' => 'unit_aria-unut_Value',
-                'data-bool-attr' => 'unit_YES',
+                'data-bool-attr' => 'on',
             ],
             $sut->prepareAttributes($attb)
         );


### PR DESCRIPTION
## Description

Translator was trying to translate an int - we had code tin place to sort this and it had been removed

Related issue: [VOL-5217](https://dvsa.atlassian.net/browse/VOL-5217)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
