### PR TITLE
fix: fix regression in `AbstractGoodsVehiclesController.php`

### DIFF
--- a/Common/src/Common/Controller/Lva/AbstractGoodsVehiclesController.php
+++ b/Common/src/Common/Controller/Lva/AbstractGoodsVehiclesController.php
@@ -172,18 +172,22 @@ abstract class AbstractGoodsVehiclesController extends AbstractController
 
         if ($request->isPost()) {
             $crudAction = $this->getCrudAction([$formData['table']]);
-            $haveCrudAction = ($crudAction !== null);
 
-            if ($haveCrudAction && $this->isInternalReadOnly()) {
+            if ($crudAction !== null && $this->isInternalReadOnly()) {
                 return $this->handleCrudAction($crudAction);
             }
 
             if ($form->isValid()) {
-                $response = $this->updateVehiclesSection($form, $haveCrudAction, $headerData);
+                $response = $this->updateVehiclesSection($form, ($crudAction !== null), $headerData);
                 if ($response !== null) {
                     return $response;
                 }
-                return $this->handleCrudAction($crudAction);
+
+                if ($crudAction !== null) {
+                    return $this->handleCrudAction($crudAction);
+                }
+
+                return $this->completeSection('vehicles');
             }
         }
 


### PR DESCRIPTION
## Description

Fixes: `AbstractGoodsVehiclesController::handleCrudAction() must be of the type array, null given`. Regressed from the static analysis ticket.

Related issue: https://dvsa.atlassian.net/browse/VOL-5230

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
