### PR TITLE
fix: String '0' should not be ignore when running filtering on search

### DIFF
--- a/Common/src/Common/Service/Data/Search/Search.php
+++ b/Common/src/Common/Service/Data/Search/Search.php
@@ -342,13 +342,9 @@ class Search extends AbstractData
         );
 
         foreach ($this->getFilters() as $filterClass) {
-            if (!isset($post['filter'][$filterClass->getKey()])) {
-                continue;
+            if (isset($post['filter'][$filterClass->getKey()]) && $post['filter'][$filterClass->getKey()] !== '') {
+                $filterClass->setValue($post['filter'][$filterClass->getKey()]);
             }
-            if (empty($post['filter'][$filterClass->getKey()]) && $post['filter'][$filterClass->getKey()] !== '0') {
-                continue;
-            }
-            $filterClass->setValue($post['filter'][$filterClass->getKey()]);
         }
     }
 

--- a/Common/src/Common/Service/Data/Search/Search.php
+++ b/Common/src/Common/Service/Data/Search/Search.php
@@ -342,11 +342,10 @@ class Search extends AbstractData
         );
 
         foreach ($this->getFilters() as $filterClass) {
-            /** @var \Common\Data\Object\Search\Aggregations\Terms\TermsAbstract $filterClass */
             if (!isset($post['filter'][$filterClass->getKey()])) {
                 continue;
             }
-            if (empty($post['filter'][$filterClass->getKey()])) {
+            if (empty($post['filter'][$filterClass->getKey()]) && $post['filter'][$filterClass->getKey()] !== '0') {
                 continue;
             }
             $filterClass->setValue($post['filter'][$filterClass->getKey()]);


### PR DESCRIPTION
## Description

empty() treating string '0' as empty, wrong assumption for filters.

Related issue: [VOL-3539](https://dvsa.atlassian.net/browse/VOL-3539)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
