### PR TITLE
fix: VOL-5243 permission service can now check for manage selfserve user permissions

### DIFF
--- a/Common/src/Common/Rbac/Service/Permission.php
+++ b/Common/src/Common/Rbac/Service/Permission.php
@@ -43,4 +43,9 @@ class Permission
 
         return (string) $currentUserId === $userId;
     }
+
+    public function canManageSelfserveUsers(): bool
+    {
+        return $this->authService->isGranted(RefData::PERMISSION_CAN_MANAGE_USER_SELFSERVE);
+    }
 }

--- a/Common/src/Common/RefData.php
+++ b/Common/src/Common/RefData.php
@@ -317,6 +317,8 @@ class RefData
 
     public const PERMISSION_CAN_MANAGE_USER_INTERNAL = 'can-manage-user-internal';
 
+    public const PERMISSION_CAN_MANAGE_USER_SELFSERVE = 'can-manage-user-selfserve';
+
     public const PERMISSION_SELFSERVE_EBSR_UPLOAD = 'selfserve-ebsr-upload';
 
     public const PERMISSION_SELFSERVE_EBSR_DOCUMENTS = 'selfserve-ebsr-documents';

--- a/test/Common/src/Common/Rbac/Service/PermissionTest.php
+++ b/test/Common/src/Common/Rbac/Service/PermissionTest.php
@@ -68,6 +68,12 @@ class PermissionTest extends MockeryTestCase
         $this->assertFalse($this->sut->isInternalReadOnly());
     }
 
+    public function testCanManageSelfserveUsers(): void
+    {
+        $this->authService->expects('isGranted')->with(RefData::PERMISSION_CAN_MANAGE_USER_SELFSERVE)->andReturnTrue();
+        $this->assertTrue($this->sut->canManageSelfserveUsers());
+    }
+
     /**
      * @dataProvider dpIsGranted
      */


### PR DESCRIPTION
## Description

Permission service can now check for permission to manage selfservice users. Fixes bug on manage users page.

Related issue: [VOL-5243](https://dvsa.atlassian.net/browse/VOL-5243)
