### PR TITLE
fix: locked php version to ~8.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Common library for the OLCS Project",
     "type": "library",
     "require": {
-        "php": "^8.0.0",
+        "php": "~8.0.0",
         "ezyang/htmlpurifier": "^4.17",
         "laminas/laminas-authentication": "^2.6",
         "laminas/laminas-cache": "^3.0",


### PR DESCRIPTION
## Description

Locked PHP version to **~8.0.0**

Related issue: https://dvsa.atlassian.net/browse/VOL-4747

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
