### PR TITLE
fix: What happens next detail missing text

### DIFF
--- a/Common/view/pages/continuation-success.phtml
+++ b/Common/view/pages/continuation-success.phtml
@@ -51,6 +51,7 @@
       <?php endif; ?>
       <?php if (!$isSpecialRestricted): ?>
         <h2><?php echo $this->translate('continuation.success.what-happens-next'); ?></h2>
+        <p><?php echo $this->translate('continuation.success.what-happens-next.detail'); ?></p>
         <div class="field">
             <p><?php printf($this->translate($this->licenceDocumentationMessage), $this->numPsvDiscs); ?></p>
         </div>


### PR DESCRIPTION
## Description

On completing a digital continuation is supposed to show heading "What happens next" with text underneath stating "Your licence documentation and vehicle discs will be sent within 5 working days" (see original story OLCS-16468. Alternative text when there are no discs detailed in OLCS-17779.)

However, the text underneath the "What happens next" heading is currently missing.

Related issue: [VOL-3003](https://dvsa.atlassian.net/browse/VOL-3003)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
