### PR TITLE
fix: convert methods `mapFromForm` and `mapFromErrors` to static

### DIFF
--- a/Common/src/Common/Data/Mapper/DefaultMapper.php
+++ b/Common/src/Common/Data/Mapper/DefaultMapper.php
@@ -24,7 +24,7 @@ class DefaultMapper implements MapperInterface
      *
      * @param array $data Data from form
      */
-    public function mapFromForm(array $data): array
+    public static function mapFromForm(array $data): array
     {
         return $data['fields'];
     }
@@ -36,7 +36,7 @@ class DefaultMapper implements MapperInterface
      * @param FormInterface $form   Form interface
      * @param array         $errors array response from errors
      */
-    public function mapFromErrors(FormInterface $form, array $errors): array
+    public static function mapFromErrors(FormInterface $form, array $errors): array
     {
         return $errors;
     }

--- a/Common/src/Common/Data/Mapper/Licence/Surrender/CommunityLicence.php
+++ b/Common/src/Common/Data/Mapper/Licence/Surrender/CommunityLicence.php
@@ -12,7 +12,7 @@ class CommunityLicence implements MapperInterface
      *
      * @param array $formData Form data
      */
-    public function mapFromForm(array $formData): array
+    public static function mapFromForm(array $formData): array
     {
         $mappedData = [
             'possession' => [

--- a/Common/src/Common/Data/Mapper/Licence/Surrender/OperatorLicence.php
+++ b/Common/src/Common/Data/Mapper/Licence/Surrender/OperatorLicence.php
@@ -12,7 +12,7 @@ class OperatorLicence implements MapperInterface
      *
      * @param array $formData Form data
      */
-    public function mapFromForm(array $formData): array
+    public static function mapFromForm(array $formData): array
     {
         $mappedData = [
             'possession' => [


### PR DESCRIPTION
## Description

Mapper methods are called statically. As of PHP 8.0 calling non-static methods statically throws an error.

Related issue: https://dvsa.atlassian.net/browse/VOL-5448

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
