### PR TITLE
fix: VOL-5466 compatibility with latest Laminas form

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceLicenceVehicle.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceLicenceVehicle.php
@@ -45,7 +45,6 @@ class LicenceLicenceVehicle
      *     "label": "application_vehicle-safety_vehicle-sub-action.licence-vehicle.specifiedDate",
      *     "create_empty_option": false,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '</fieldset><fieldset><div class=""field""><label for=""hearingDate"">Specified time</label>'HH:mm:ss'</div>'",
      *     "field": "specifiedDate",
      *     "default_date": "now",
      *     "display_every_minute": true

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceVehicle.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceVehicle.php
@@ -45,7 +45,6 @@ class LicenceVehicle
      *     "label": "application_vehicle-safety_vehicle-sub-action.licence-vehicle.specifiedDate",
      *     "create_empty_option": false,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '</fieldset><fieldset><div class=""field""><label for=""hearingDate"">Specified time</label>'HH:mm:ss'</div>'",
      *     "field": "specifiedDate",
      *     "month_attributes": {"disabled":"disabled"},
      *     "year_attributes": {"disabled":"disabled"},

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceVehicleAppVar.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/LicenceVehicleAppVar.php
@@ -45,7 +45,6 @@ class LicenceVehicleAppVar
      *     "label": "application_vehicle-safety_vehicle-sub-action.licence-vehicle.specifiedDate",
      *     "create_empty_option": false,
      *     "render_delimiters": true,
-     *     "pattern": "d MMMM y '</fieldset><fieldset><div class=""field""><label for=""hearingDate"">Specified time</label>'HH:mm:ss'</div>'",
      *     "field": "specifiedDate",
      *     "month_attributes": {"disabled":"disabled"},
      *     "year_attributes": {"disabled":"disabled"},


### PR DESCRIPTION
## Description

Latest Laminas Form no longer allows for our custom HTML as it strips out <> characters. Returning formatting to the default INTL pattern.

Related issue: [VOL-5466](https://dvsa.atlassian.net/browse/VOL-5466)
