### PR TITLE
feat: make messaging timeframe string an editable translation

### DIFF
--- a/Common/config/language/partials/en_GB/markup-messaging-new-conversation-timeframe.phtml
+++ b/Common/config/language/partials/en_GB/markup-messaging-new-conversation-timeframe.phtml
@@ -1,3 +1,3 @@
 <div class="govuk-inset-text">
-  It can take up to 48 hours for a caseworker to reply to your message.
+  <?php echo $this->escapeHtml($this->translate('markup-messaging-new-conversation-timeframe')); ?>
 </div>


### PR DESCRIPTION
## Description

Make the response timeframe text under create new message thread on self-serve an editable translation

Related issue: [VOL-5525](https://dvsa.atlassian.net/browse/VOL-5525)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
