### PR TITLE
fix: Revert translation key fallback view

### DIFF
--- a/Common/config/language/partials/en_GB/markup-messaging-new-conversation-timeframe.phtml
+++ b/Common/config/language/partials/en_GB/markup-messaging-new-conversation-timeframe.phtml
@@ -1,3 +1,3 @@
 <div class="govuk-inset-text">
-  <?php echo $this->escapeHtml($this->translate('markup-messaging-new-conversation-timeframe')); ?>
+  It can take up to 48 hours for a caseworker to reply to your message.
 </div>

--- a/Common/config/language/partials/en_GB/markup-messaging-new-conversation-timeframe.phtml
+++ b/Common/config/language/partials/en_GB/markup-messaging-new-conversation-timeframe.phtml
@@ -1,3 +1,3 @@
 <div class="govuk-inset-text">
-  It can take up to 48 hours for a caseworker to reply to your message.
+  It can take several working days for a caseworker to reply to your message.
 </div>


### PR DESCRIPTION
## Description

Remove call to translate - this view is actually a fallback for the same translation key which was just not defined.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
