### PR TITLE
feat: remove caseworkers family name on `selfserve`

### DIFF
--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -33,13 +33,6 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
         // If createdBy (User) has a Team, they are an internal user.
         $internalCaseworkerTeam = (empty($row['createdBy']['team'])) ? '' : '<p class="govuk-caption-m">' . $senderName . '<br/>Caseworker Team</p>';
 
-        // If running on 'selfserve' remove caseworker's family name.
-        if (str_contains(__FILE__, 'selfserve') && $internalCaseworkerTeam) {
-            $caseworkerFamilyName = explode(' ', $senderName)[1];
-            $senderName = str_replace($caseworkerFamilyName, '', $senderName);
-            $internalCaseworkerTeam = str_replace($caseworkerFamilyName, '', $internalCaseworkerTeam);
-        }
-
         return strtr($this->rowTemplate, [
             '{senderName}' => $senderName,
             '{messageDate}' => $date,
@@ -48,6 +41,11 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
             '{fileList}' => $fileList,
             '{firstReadBy}' => $firstReadBy,
         ]);
+    }
+
+    protected function isInternalUser($row): bool
+    {
+        return !empty($row['createdBy']['team']);
     }
 
     /**

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -33,6 +33,13 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
         // If createdBy (User) has a Team, they are an internal user.
         $internalCaseworkerTeam = (empty($row['createdBy']['team'])) ? '' : '<p class="govuk-caption-m">' . $senderName . '<br/>Caseworker Team</p>';
 
+        // If running on 'selfserve' remove caseworker's family name.
+        if (str_contains(__FILE__, 'selfserve')) {
+            $caseworkerFamilyName = explode(' ', $senderName)[1];
+            $senderName = str_replace($caseworkerFamilyName, '', $senderName);
+            $internalCaseworkerTeam = str_replace($caseworkerFamilyName, '', $internalCaseworkerTeam);
+        }
+
         return strtr($this->rowTemplate, [
             '{senderName}' => $senderName,
             '{messageDate}' => $date,

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -34,7 +34,7 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
         $internalCaseworkerTeam = (empty($row['createdBy']['team'])) ? '' : '<p class="govuk-caption-m">' . $senderName . '<br/>Caseworker Team</p>';
 
         // If running on 'selfserve' remove caseworker's family name.
-        if (str_contains(__FILE__, 'selfserve')) {
+        if (str_contains(__FILE__, 'selfserve') && $internalCaseworkerTeam) {
             $caseworkerFamilyName = explode(' ', $senderName)[1];
             $senderName = str_replace($caseworkerFamilyName, '', $senderName);
             $internalCaseworkerTeam = str_replace($caseworkerFamilyName, '', $internalCaseworkerTeam);

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
@@ -22,7 +22,8 @@ class ExternalConversationMessage extends AbstractConversationMessage
         </div>
     ';
 
-    protected function getSenderName(array $row): string {
+    protected function getSenderName(array $row): string
+    {
         if (!empty($row['createdBy']['contactDetails']['person'])) {
             $person = $row['createdBy']['contactDetails']['person'];
             $senderName = $person['forename'];

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
@@ -21,4 +21,18 @@ class ExternalConversationMessage extends AbstractConversationMessage
             </div>
         </div>
     ';
+
+    protected function getSenderName(array $row): string {
+        if (!empty($row['createdBy']['contactDetails']['person'])) {
+            $person = $row['createdBy']['contactDetails']['person'];
+            $senderName = $person['forename'];
+            if (!$this->isInternalUser($row)) {
+                $senderName .= " " . $person['familyName'];
+            }
+        } else {
+            $senderName = $row['createdBy']['loginId'];
+        }
+
+        return $senderName;
+    }
 }


### PR DESCRIPTION
## Description
remove caseworkers family name in messages on `selfserve`

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
