### PR TITLE
feat: Set SameSite cookie attr to clean up some console warnings

### DIFF
--- a/Common/src/Common/Preference/Language.php
+++ b/Common/src/Common/Preference/Language.php
@@ -82,6 +82,7 @@ class Language implements FactoryInterface
         $this->requestCookie->setValue($this->preference);
         $this->requestCookie->setPath('/');
         $this->requestCookie->setExpires(strtotime('+10 years'));
+        $this->requestCookie->setSameSite('Strict');
         /** @var Response $response */
         $response = $container->get('Response');
         $response->getHeaders()->addHeader($this->requestCookie);

--- a/test/Common/src/Common/Preference/LanguageTest.php
+++ b/test/Common/src/Common/Preference/LanguageTest.php
@@ -84,6 +84,7 @@ class LanguageTest extends MockeryTestCase
         $this->assertInstanceOf(SetCookie::class, $this->setCookie);
 
         $this->assertEquals('cy', $this->setCookie->getValue());
+        $this->assertEquals('Strict', $this->setCookie->getSameSite());
     }
 
     public function testSetPreferenceException(): void


### PR DESCRIPTION
## Description

Fixes a console warning regarding langPref cookie

Related issue: [VOL-5555]

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
