### PR TITLE
fix: Make messaging status tags the correct case for GDS frontend

### DIFF
--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationStatus.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationStatus.php
@@ -26,7 +26,7 @@ class ExternalConversationStatus implements FormatterPluginManagerInterface
         return sprintf(
             '<strong class="govuk-tag %s">%s</strong>',
             $tagColor,
-            str_replace('_', ' ', $row['userContextStatus']),
+            ucfirst(strtolower(str_replace('_', ' ', $row['userContextStatus']))),
         );
     }
 }

--- a/test/Common/src/Common/Service/Table/Formatter/ExternalConversationStatusTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/ExternalConversationStatusTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Service\Table\Formatter;
+
+use Common\Service\Table\Formatter\ExternalConversationStatus;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ExternalConversationStatus test
+ */
+class ExternalConversationStatusTest extends TestCase
+{
+    /**
+     * Test messaging conversation status formatter
+     *
+     * @dataProvider statusProvider
+     */
+    public function testFormat($row, $expected): void
+    {
+        $formatter = new ExternalConversationStatus();
+        $this->assertEquals($expected, $formatter->format($row));
+    }
+
+    /**
+     * @return array
+     */
+    public function statusProvider(): array
+    {
+        return [
+            'new_message' => [
+                ['userContextStatus' => 'NEW_MESSAGE'],
+                '<strong class="govuk-tag govuk-tag--red">New message</strong>',
+            ],
+            'open' => [
+                ['userContextStatus' => 'OPEN'],
+                '<strong class="govuk-tag govuk-tag--blue">Open</strong>',
+            ],
+            'closed' => [
+                ['userContextStatus' => 'CLOSED'],
+                '<strong class="govuk-tag govuk-tag--grey">Closed</strong>',
+            ],
+            'default' => [
+                ['userContextStatus' => 'DEFAULT_OTHER_STATUS'],
+                '<strong class="govuk-tag govuk-tag--green">Default other status</strong>',
+            ],
+        ];
+    }
+}
+

--- a/test/Common/src/Common/Service/Table/Formatter/ExternalConversationStatusTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/ExternalConversationStatusTest.php
@@ -48,4 +48,3 @@ class ExternalConversationStatusTest extends TestCase
         ];
     }
 }
-


### PR DESCRIPTION
## Description

Lowercase some UPPERCASE Tag labels.

Related issue: [VOL-5669](https://dvsa.atlassian.net/browse/VOL-5669)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
