### PR TITLE
fix: show conversation for variations vol 5661

### DIFF
--- a/Common/src/Common/Service/Table/Formatter/InternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/InternalConversationLink.php
@@ -39,7 +39,7 @@ class InternalConversationLink implements FormatterPluginManagerInterface
             case 'application':
                 $route = 'lva-application/conversation/view';
                 $params = [
-                    'application' => $row['task']['application']['id'],
+                    'application' => $this->route->getParam('application'),
                 ];
                 break;
             case 'licence':


### PR DESCRIPTION
## Description

No conversations were being shown when making a variation **IF** a conversation was made on the licence.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
