### PR TITLE
fix: fix pattern escape console error align with validator

### DIFF
--- a/Common/src/Common/Form/Elements/InputFilters/Phone.php
+++ b/Common/src/Common/Form/Elements/InputFilters/Phone.php
@@ -20,7 +20,7 @@ class Phone extends LaminasElement implements InputProviderInterface
      */
     public function init(): void
     {
-        $this->setAttribute('pattern', '\d(\+|\-|\(|\))*');
+        $this->setAttribute('pattern', '^$|^[0-9][0-9 ]*$');
         $this->setLabel('contact-number-optional');
         parent::init();
     }

--- a/Common/src/Common/Form/Elements/InputFilters/Phone.php
+++ b/Common/src/Common/Form/Elements/InputFilters/Phone.php
@@ -20,7 +20,7 @@ class Phone extends LaminasElement implements InputProviderInterface
      */
     public function init(): void
     {
-        $this->setAttribute('pattern', '^$|^[0-9][0-9 ]*$');
+        $this->setAttribute('pattern', '/^[0-9 \(\)\-\+]+$/');
         $this->setLabel('contact-number-optional');
         parent::init();
     }

--- a/Common/src/Common/Form/Elements/InputFilters/Phone.php
+++ b/Common/src/Common/Form/Elements/InputFilters/Phone.php
@@ -20,7 +20,7 @@ class Phone extends LaminasElement implements InputProviderInterface
      */
     public function init(): void
     {
-        $this->setAttribute('pattern', '/^[0-9 \(\)\-\+]+$/');
+        $this->setAttribute('pattern', '\d(\+|-|\(|\))*');
         $this->setLabel('contact-number-optional');
         parent::init();
     }

--- a/test/Common/src/Common/Form/Elements/InputFilters/PhoneRequiredTest.php
+++ b/test/Common/src/Common/Form/Elements/InputFilters/PhoneRequiredTest.php
@@ -17,7 +17,7 @@ class PhoneRequiredTest extends MockeryTestCase
 
         $sut->init();
 
-        static::assertSame('\d(\+|\-|\(|\))*', $sut->getAttribute('pattern'));
+        static::assertSame('\d(\+|-|\(|\))*', $sut->getAttribute('pattern'));
         static::assertSame('contact-number', $sut->getLabel());
     }
 

--- a/test/Common/src/Common/Form/Elements/InputFilters/PhoneTest.php
+++ b/test/Common/src/Common/Form/Elements/InputFilters/PhoneTest.php
@@ -17,7 +17,7 @@ class PhoneTest extends MockeryTestCase
 
         $sut->init();
 
-        static::assertSame('\d(\+|\-|\(|\))*', $sut->getAttribute('pattern'));
+        static::assertSame('^$|^[0-9][0-9 ]*$', $sut->getAttribute('pattern'));
         static::assertSame('contact-number-optional', $sut->getLabel());
     }
 

--- a/test/Common/src/Common/Form/Elements/InputFilters/PhoneTest.php
+++ b/test/Common/src/Common/Form/Elements/InputFilters/PhoneTest.php
@@ -17,7 +17,7 @@ class PhoneTest extends MockeryTestCase
 
         $sut->init();
 
-        static::assertSame('^$|^[0-9][0-9 ]*$', $sut->getAttribute('pattern'));
+        static::assertSame('\d(\+|-|\(|\))*', $sut->getAttribute('pattern'));
         static::assertSame('contact-number-optional', $sut->getLabel());
     }
 


### PR DESCRIPTION
## Description

Fix an input pattern causing console errors - align it to form validator regex.

Related issue: [VOL-5696](https://dvsa.atlassian.net/browse/VOL-5696)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
