### PR TITLE
feat: Render form elements in order defined; not fieldset first

### DIFF
--- a/Common/src/Common/Form/View/Helper/Form.php
+++ b/Common/src/Common/Form/View/Helper/Form.php
@@ -25,7 +25,6 @@ class Form extends \Laminas\Form\View\Helper\Form
         if (method_exists($form, 'prepare')) {
             $form->prepare();
         }
-        $fieldsets = [];
         $elements = [];
         $hiddenSubmitElement = '';
 
@@ -70,7 +69,7 @@ class Form extends \Laminas\Form\View\Helper\Form
                     $element->get('table')->setMessages($errors);
                 }
 
-                $fieldsets[] = $view->addTags(
+                $elements[] = $view->addTags(
                     $view->formCollection($element)
                 );
             } elseif ($element->getName() === 'form-actions[continue]') {
@@ -81,10 +80,9 @@ class Form extends \Laminas\Form\View\Helper\Form
         }
 
         return sprintf(
-            '%s%s%s%s%s',
+            '%s%s%s%s',
             $includeFormTags ? $this->openTag($form) : '',
             $hiddenSubmitElement,
-            implode("\n", $fieldsets),
             implode("\n", $elements),
             $includeFormTags ? $this->closeTag() : ''
         );


### PR DESCRIPTION
## Description

Render form elements by the order in which they are defined.

Currently, fieldsets are rended before elements.

Related issue: https://dvsa.atlassian.net/browse/VOL-5713

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
