### PR TITLE
fix: ensure submit button renders at the end of the continuation form

### DIFF
--- a/Common/src/Common/Form/Model/Form/Continuation/Finances.php
+++ b/Common/src/Common/Form/Model/Form/Continuation/Finances.php
@@ -23,6 +23,7 @@ class Finances
      * })
      * @Form\Options({"label":"Continue"})
      * @Form\Type("\Laminas\Form\Element\Button")
+     * @Form\Flags({"priority": -10})
      */
     public $submit;
 }


### PR DESCRIPTION
## Description

Fix form button moved after asset update.

Related issue: [VOL-5834](https://dvsa.atlassian.net/browse/VOL-5834)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
