### PR TITLE
feat: disable remove button for last operator-admin

### DIFF
--- a/Common/src/Common/Rbac/Service/Permission.php
+++ b/Common/src/Common/Rbac/Service/Permission.php
@@ -46,8 +46,8 @@ class Permission
         return $this->authService->isGranted(RefData::PERMISSION_CAN_MANAGE_USER_SELFSERVE);
     }
 
-    public function canRemoveSelfserveUser(string $userId): bool
+    public function canRemoveSelfserveUser(string $userId, bool $disableRemove = false): bool
     {
-        return $this->canManageSelfserveUsers() && !$this->isSelf($userId);
+        return $this->canManageSelfserveUsers() && !$this->isSelf($userId) && !$disableRemove;
     }
 }

--- a/Common/src/Common/Service/Table/TableBuilder.php
+++ b/Common/src/Common/Service/Table/TableBuilder.php
@@ -385,8 +385,8 @@ class TableBuilder implements \Stringable
     {
         $operatorAdminKeys = [];
         foreach ($rows as $key => $row) {
-            $rows[$key]['disableRemove'] = false;
             if (isset($row['roles']) && is_array($row['roles'])) {
+                $rows[$key]['disableRemove'] = false;
                 $roles = array_column($row['roles'], 'role');
 
                 if (in_array('operator-admin', $roles, true)) {

--- a/Common/src/Common/Service/Table/TableBuilder.php
+++ b/Common/src/Common/Service/Table/TableBuilder.php
@@ -383,6 +383,23 @@ class TableBuilder implements \Stringable
      */
     public function setRows($rows)
     {
+        $operatorAdminKeys = [];
+        foreach ($rows as $key => $row) {
+            $rows[$key]['disableRemove'] = false;
+            if (isset($row['roles']) && is_array($row['roles'])) {
+                $roles = array_column($row['roles'], 'role');
+
+                if (in_array('operator-admin', $roles, true)) {
+                    $operatorAdminKeys[] = $key;
+                }
+            }
+        }
+
+        if (count($operatorAdminKeys) === 1) {
+            $adminKey = $operatorAdminKeys[0];
+            $rows[$adminKey]['disableRemove'] = true;
+        }
+
         $this->rows = $rows;
         return $this;
     }


### PR DESCRIPTION
## Description
Disable the remove button for the last `operator-admin`. 

Related issue: [4718](https://dvsa.atlassian.net/browse/VOL-4718)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?

## Related PR
[vol-app#380](https://github.com/dvsa/vol-app/pull/380)
