### PR TITLE
feat: remove option to change correspondence type

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/BusinessDetails.php
+++ b/Common/src/Common/Form/Model/Form/Lva/BusinessDetails.php
@@ -35,12 +35,6 @@ class BusinessDetails
     public $table;
 
     /**
-     * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\BusinessDetailsAllowEmail")
-     * @Form\Name("allow-email")
-     */
-    public $allowEmail;
-
-    /**
      * @Form\Name("form-actions")
      * @Form\ComposedObject("Common\Form\Model\Form\Lva\Fieldset\FormActions")
      * @Form\Attributes({"class":"govuk-button-group"})


### PR DESCRIPTION
## Description
Remove the option to change correspondence type on selfserve.
Internal users can still change the correspondence type if needed.

Related issue: [5774](https://dvsa.atlassian.net/browse/VOL-5774)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?

## Related PRs
https://github.com/dvsa/olcs-etl/pull/70
https://github.com/dvsa/vol-app/pull/428
