### PR TITLE
feat: VOL-4718 permission service prevents last operator admin being deleted

### DIFF
--- a/Common/src/Common/Rbac/Service/Permission.php
+++ b/Common/src/Common/Rbac/Service/Permission.php
@@ -46,8 +46,21 @@ class Permission
         return $this->authService->isGranted(RefData::PERMISSION_CAN_MANAGE_USER_SELFSERVE);
     }
 
-    public function canRemoveSelfserveUser(string $userId): bool
+    /**
+     * $role, is the role of the user being deleted, as opposed to the role of the user doing the deleting
+     */
+    public function canRemoveSelfserveUser(string $userId, string $role): bool
     {
+        /**
+         * we have to check the auth service to see if operator admins can be deleted,
+         * since this needs calculating at an organisation level
+         *
+         * what we're preventing here is the last operator admin being deleted
+         */
+        if ($role === RefData::ROLE_OPERATOR_ADMIN && !$this->authService->getIdentity()->getUserData()['canDeleteOperatorAdmin']) {
+            return false;
+        }
+
         return $this->canManageSelfserveUsers() && !$this->isSelf($userId);
     }
 }


### PR DESCRIPTION
Related issue: [VOL-4718](https://dvsa.atlassian.net/browse/VOL-4718)
