### PR TITLE
feat: notify user document has been uploaded

### DIFF
--- a/Common/src/Common/Form/Elements/Types/FileUploadList.php
+++ b/Common/src/Common/Form/Elements/Types/FileUploadList.php
@@ -72,6 +72,10 @@ class FileUploadList extends Fieldset
                 . $file['description'] . '</a> <span>' . $file['size'] . '</span>'
             );
 
+            $html->setValue(
+                '<strong class="govuk-tag">Uploaded</strong>'
+            );
+
             $remove = new Submit('remove', ['render-container' => false]);
             $remove->setValue('Remove');
             $remove->setAttribute('class', 'file__remove action-button-link');


### PR DESCRIPTION
## Description

When a document has been uploaded a tag will be added to notify the user that the the operation was successful 

Related issue: [VOL-5986](https://dvsa.atlassian.net/browse/VOL-5986)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
