### PR TITLE
fix: hidden messages when a user is deleted

### DIFF
--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -11,6 +11,8 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
 {
     protected string $rowTemplate;
 
+    protected string $defaultSenderName = "Sent by user now deleted";
+
     /**
      * status
      *
@@ -130,11 +132,15 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
 
     protected function getSenderName(array $row): string
     {
-        if (!empty($row['createdBy']['contactDetails']['person'])) {
-            $person = $row['createdBy']['contactDetails']['person'];
-            $senderName = $person['forename'] . " " . $person['familyName'];
-        } else {
-            $senderName = $row['createdBy']['loginId'];
+        $senderName = $this->defaultSenderName;
+
+        if(!empty($row['createdBy'])) {
+            if (!empty($row['createdBy']['contactDetails']['person'])) {
+                $person = $row['createdBy']['contactDetails']['person'];
+                $senderName = $person['forename'] . " " . $person['familyName'];
+            } else {
+                $senderName = $row['createdBy']['loginId'];
+            }
         }
 
         return $senderName;

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -134,7 +134,7 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
     {
         $senderName = $this->defaultSenderName;
 
-        if(!empty($row['createdBy'])) {
+        if (!empty($row['createdBy'])) {
             if (!empty($row['createdBy']['contactDetails']['person'])) {
                 $person = $row['createdBy']['contactDetails']['person'];
                 $senderName = $person['forename'] . " " . $person['familyName'];

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationMessage.php
@@ -24,14 +24,18 @@ class ExternalConversationMessage extends AbstractConversationMessage
 
     protected function getSenderName(array $row): string
     {
-        if (!empty($row['createdBy']['contactDetails']['person'])) {
-            $person = $row['createdBy']['contactDetails']['person'];
-            $senderName = $person['forename'];
-            if (!$this->isInternalUser($row)) {
-                $senderName .= " " . $person['familyName'];
+        $senderName = $this->defaultSenderName;
+
+        if (!empty($row['createdBy'])) {
+            if (!empty($row['createdBy']['contactDetails']['person'])) {
+                $person = $row['createdBy']['contactDetails']['person'];
+                $senderName = $person['forename'];
+                if (!$this->isInternalUser($row)) {
+                    $senderName .= " " . $person['familyName'];
+                }
+            } else {
+                $senderName = $row['createdBy']['loginId'];
             }
-        } else {
-            $senderName = $row['createdBy']['loginId'];
         }
 
         return $senderName;


### PR DESCRIPTION
## Description

Fixing a bug where messages are hidden when a user, that is part of the conversation, is deleted.

Related issue: [VOL-5987](https://dvsa.atlassian.net/browse/VOL-5987)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?

## Relevant PRs

[vol-app#668](https://github.com/dvsa/vol-app/pull/668)

[VOL-5987]: https://dvsa.atlassian.net/browse/VOL-5987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ