### PR TITLE
fix: set unlink flag so unwanted uploads are unlinked from licence in event history

### DIFF
--- a/Common/src/Common/Controller/Traits/GenericUpload.php
+++ b/Common/src/Common/Controller/Traits/GenericUpload.php
@@ -103,7 +103,7 @@ trait GenericUpload
     public function deleteFile($id)
     {
         /** @var \Common\Service\Cqrs\Response $response */
-        $response = $this->handleCommand(DeleteDocument::create(['id' => $id]));
+        $response = $this->handleCommand(DeleteDocument::create(['id' => $id, 'unlinkLicence' => true]));
 
         return $response->isOk();
     }


### PR DESCRIPTION
## Description

Set unlink flag for deletions happening from upload form while user is choosing documents to upload

Related issue: [VOL-5967](https://dvsa.atlassian.net/browse/VOL-5967)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?


[VOL-5967]: https://dvsa.atlassian.net/browse/VOL-5967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ