### PR TITLE
feat: update time on VOL messaging to use correct timezone

### DIFF
--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -15,35 +15,31 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
 
     /**
      * status
-     *
-     * @param array $row Row data
-     * @param array $column Column data
-     *
      * @inheritdoc
      */
-    public function format($row, $column = null): string
+    public function format(array $data, array $column = null): string
     {
-        $senderName = $this->getSenderName($row);
+        $senderName = $this->getSenderName($data);
 
-        // $row["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
+        // $data["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
         // third parameter. to override it we need to force set the timezone to the default one
         $latestMessageCreatedAt = DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM, $row["createdOn"]
-        )->setTimezone(new \DateTimeZone(date_default_timezone_get()));;
+            DateTimeInterface::ATOM, $data["createdOn"]
+        )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $date = $latestMessageCreatedAt->format('l j F Y \a\t H:ia');
 
-        $fileList = $this->getFileList($row);
+        $fileList = $this->getFileList($data);
 
-        $firstReadBy = $this->getFirstReadBy($row);
+        $firstReadBy = $this->getFirstReadBy($data);
 
         // If createdBy (User) has a Team, they are an internal user.
-        $internalCaseworkerTeam = (empty($row['createdBy']['team'])) ? '' : '<p class="govuk-caption-m">' . $senderName . '<br/>Caseworker Team</p>';
+        $internalCaseworkerTeam = (empty($data['createdBy']['team'])) ? '' : '<p class="govuk-caption-m">' . $senderName . '<br/>Caseworker Team</p>';
 
         return strtr($this->rowTemplate, [
             '{senderName}' => $senderName,
             '{messageDate}' => $date,
-            '{messageBody}' => nl2br($row['messagingContent']['text']),
+            '{messageBody}' => nl2br($data['messagingContent']['text']),
             '{caseworkerFooter}' => $internalCaseworkerTeam,
             '{fileList}' => $fileList,
             '{firstReadBy}' => $firstReadBy,

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -25,7 +25,12 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
     {
         $senderName = $this->getSenderName($row);
 
-        $latestMessageCreatedAt = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $row["createdOn"]);
+        // $row["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
+        // third parameter. to override it we need to force set the timezone to the default one
+        $latestMessageCreatedAt = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ATOM, $row["createdOn"]
+        )->setTimezone(new \DateTimeZone(date_default_timezone_get()));;
+
         $date = $latestMessageCreatedAt->format('l j F Y \a\t H:ia');
 
         $fileList = $this->getFileList($row);

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -24,7 +24,8 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
         // $data["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
         // third parameter. to override it we need to force set the timezone to the default one
         $latestMessageCreatedAt = DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM, $data["createdOn"]
+            DateTimeInterface::ATOM,
+            $data["createdOn"]
         )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $date = $latestMessageCreatedAt->format('l j F Y \a\t H:ia');

--- a/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
+++ b/Common/src/Common/Service/Table/Formatter/AbstractConversationMessage.php
@@ -17,7 +17,7 @@ abstract class AbstractConversationMessage implements FormatterPluginManagerInte
      * status
      * @inheritdoc
      */
-    public function format(array $data, array $column = null): string
+    public function format(array $data, array $column = []): string
     {
         $senderName = $this->getSenderName($data);
 

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
@@ -6,6 +6,7 @@ namespace Common\Service\Table\Formatter;
 
 use Common\Service\Helper\UrlHelperService;
 use Common\Util\Escape;
+use DateInvalidTimeZoneException;
 use DateTimeImmutable;
 use DateTimeInterface;
 
@@ -18,20 +19,17 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
     /**
      * status
      *
-     * @param array $row Row data
-     * @param array $column Column data
-     *
-     * @inheritdoc
+     * @throws DateInvalidTimeZoneException
      */
-    public function format($row, $column = null): string
+    public function format( array $data, array $column = null): string
     {
         $route = 'conversations/view';
         $params = [
-            'conversationId' => $row['id'],
+            'conversationId' => $data['id'],
         ];
 
         $statusCSS = '';
-        if ($row['userContextStatus'] === "NEW_MESSAGE") {
+        if ($data['userContextStatus'] === "NEW_MESSAGE") {
             $statusCSS = 'govuk-!-font-weight-bold';
         }
 
@@ -41,18 +39,18 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
             <p class="govuk-body govuk-!-margin-1">%s</p>
         ';
 
-        // $row["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
+        // $data["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
         // third parameter. to override it we need to force set the timezone to the default one
         $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM, $row["createdOn"]
+            DateTimeInterface::ATOM, $data["createdOn"]
         )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $dtOutput = $latestMessageCreatedOn->format('l j F Y \a\t H:ia');
 
-        if (isset($row['task']['application']['id'])) {
-            $idMatrix = Escape::html($row['task']['licence']['licNo'] . " / " . $row['task']['application']['id']);
+        if (isset($data['task']['application']['id'])) {
+            $idMatrix = Escape::html($data['task']['licence']['licNo'] . " / " . $data['task']['application']['id']);
         } else {
-            $idMatrix = Escape::html($row['task']['licence']['licNo']);
+            $idMatrix = Escape::html($data['task']['licence']['licNo']);
         }
 
         return vsprintf(
@@ -61,7 +59,7 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
                 $statusCSS,
                 $this->urlHelper->fromRoute($route, $params),
                 $idMatrix,
-                $row["subject"],
+                $data["subject"],
                 $dtOutput,
             ],
         );

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
@@ -18,7 +18,7 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
     /**
      * status
      */
-    public function format(array $data, array $column = null): string
+    public function format(array $data, array $column = []): string
     {
         $route = 'conversations/view';
         $params = [

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
@@ -6,7 +6,6 @@ namespace Common\Service\Table\Formatter;
 
 use Common\Service\Helper\UrlHelperService;
 use Common\Util\Escape;
-use DateInvalidTimeZoneException;
 use DateTimeImmutable;
 use DateTimeInterface;
 
@@ -18,10 +17,8 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
 
     /**
      * status
-     *
-     * @throws DateInvalidTimeZoneException
      */
-    public function format( array $data, array $column = null): string
+    public function format(array $data, array $column = null): string
     {
         $route = 'conversations/view';
         $params = [
@@ -42,7 +39,8 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
         // $data["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
         // third parameter. to override it we need to force set the timezone to the default one
         $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM, $data["createdOn"]
+            DateTimeInterface::ATOM,
+            $data["createdOn"]
         )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $dtOutput = $latestMessageCreatedOn->format('l j F Y \a\t H:ia');

--- a/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/ExternalConversationLink.php
@@ -41,7 +41,12 @@ class ExternalConversationLink implements FormatterPluginManagerInterface
             <p class="govuk-body govuk-!-margin-1">%s</p>
         ';
 
-        $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $row["createdOn"]);
+        // $row["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
+        // third parameter. to override it we need to force set the timezone to the default one
+        $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ATOM, $row["createdOn"]
+        )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
         $dtOutput = $latestMessageCreatedOn->format('l j F Y \a\t H:ia');
 
         if (isset($row['task']['application']['id'])) {

--- a/Common/src/Common/Service/Table/Formatter/FormatterPluginManagerInterface.php
+++ b/Common/src/Common/Service/Table/Formatter/FormatterPluginManagerInterface.php
@@ -4,5 +4,5 @@ namespace Common\Service\Table\Formatter;
 
 interface FormatterPluginManagerInterface
 {
-    public function format($data, $column = []);
+    public function format(array $data, array $column = []);
 }

--- a/Common/src/Common/Service/Table/Formatter/InternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/InternalConversationLink.php
@@ -93,7 +93,12 @@ class InternalConversationLink implements FormatterPluginManagerInterface
                 break;
         }
 
-        $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $row["createdOn"]);
+        // $row["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
+        // third parameter. to override it we need to force set the timezone to the default one
+        $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(
+            DateTimeInterface::ATOM, $row["createdOn"]
+        )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
         $dtOutput = $latestMessageCreatedOn->format('l j F Y \a\t H:ia');
 
         if (isset($row['task']['application']['id'])) {

--- a/Common/src/Common/Service/Table/Formatter/InternalConversationLink.php
+++ b/Common/src/Common/Service/Table/Formatter/InternalConversationLink.php
@@ -96,7 +96,8 @@ class InternalConversationLink implements FormatterPluginManagerInterface
         // $row["createdOn"] already contains a timezone so createFromFormat will ignore any timezone passed as the
         // third parameter. to override it we need to force set the timezone to the default one
         $latestMessageCreatedOn = DateTimeImmutable::createFromFormat(
-            DateTimeInterface::ATOM, $row["createdOn"]
+            DateTimeInterface::ATOM,
+            $row["createdOn"]
         )->setTimezone(new \DateTimeZone(date_default_timezone_get()));
 
         $dtOutput = $latestMessageCreatedOn->format('l j F Y \a\t H:ia');

--- a/test/Common/src/Common/Form/Elements/Custom/DateTimeSelectTest.php
+++ b/test/Common/src/Common/Form/Elements/Custom/DateTimeSelectTest.php
@@ -17,6 +17,7 @@ class DateTimeSelectTest extends \PHPUnit\Framework\TestCase
     protected function setUp(): void
     {
         $this->sut = new DateTimeSelect();
+        date_default_timezone_set('UTC');
     }
 
     public function testSetValueNull(): void

--- a/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
@@ -2,13 +2,9 @@
 
 namespace CommonTest\Common\Service\Table\Formatter;
 
-use Common\Service\Helper\UrlHelperService;
 use Common\Service\Table\Formatter\AbstractConversationMessage;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use PHPUnit\Framework\TestCase;
 
 /**
  * ExternalConversationLinkLink test

--- a/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
@@ -22,6 +22,7 @@ class AbstractConversationMessageTest extends MockeryTestCase
 
         $reflection = new \ReflectionClass($this->sut);
         $property = $reflection->getProperty('rowTemplate');
+        $property->setAccessible(true);
         $property->setValue($this->sut, '<<<HTML
 <div>
     <p>{senderName}</p>

--- a/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
@@ -11,7 +11,6 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
  */
 class AbstractConversationMessageTest extends MockeryTestCase
 {
-
     /** @var AbstractConversationMessage */
     private $sut;
 

--- a/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/AbstractConversationMessageTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace CommonTest\Common\Service\Table\Formatter;
+
+use Common\Service\Helper\UrlHelperService;
+use Common\Service\Table\Formatter\AbstractConversationMessage;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ExternalConversationLinkLink test
+ */
+class AbstractConversationMessageTest extends MockeryTestCase
+{
+
+    /** @var AbstractConversationMessage */
+    private $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = m::mock(AbstractConversationMessage::class)
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+
+        $reflection = new \ReflectionClass($this->sut);
+        $property = $reflection->getProperty('rowTemplate');
+        $property->setValue($this->sut, '<<<HTML
+<div>
+    <p>{senderName}</p>
+    <time>{messageDate}</time>
+    <div>{messageBody}</div>
+    {caseworkerFooter}
+    {fileList}
+    {firstReadBy}
+</div>
+HTML;');
+
+        date_default_timezone_set('Europe/London');
+    }
+
+    /**
+     * @dataProvider messageFormatProvider
+     */
+    public function testFormatIncludesExpectedParts(
+        array $row,
+        string $expectedSenderName,
+        string $expectedFileList,
+        string $expectedReadBy,
+    ): void {
+
+        $this->sut->allows('getSenderName')
+            ->with($row)
+            ->andReturn($expectedSenderName);
+
+        $this->sut->allows('getFileList')
+            ->with($row)
+            ->andReturn($expectedFileList);
+
+        $this->sut->allows('getFirstReadBy')
+            ->with($row)
+            ->andReturn($expectedReadBy);
+
+        $output = $this->sut->format($row);
+
+        $expectedDate = (new \DateTimeImmutable($row['createdOn']))
+            ->setTimezone(new \DateTimeZone(date_default_timezone_get()))
+            ->format('l j F Y \a\t H:ia');
+
+        $this->assertStringContainsString($expectedDate, $output);
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    /**
+     * @dataProvider messageFormatProvider
+     */
+    public function messageFormatProvider(): array
+    {
+        return [
+            'external_user_message' => [
+                [
+                    'id' => 1,
+                    'version' => 1,
+                    'createdOn' => '2025-05-15T10:00:00+00:00', // Should convert to 11:00am in BST
+                    'lastModifiedOn' => null,
+                    'createdBy' => [
+                        'accountDisabled' => 'N',
+                        'disabledDate' => null,
+                        'id' => 1,
+                        'lastLoginAt' => null,
+                        'loginId' => 'system',
+                        'pid' => 'bbc5e661e106c6dcd8dc6dd186454c2fcba3c710fb4d8e71a60c93eaf077f073',
+                        'translateToWelsh' => 'N',
+                        'termsAgreed' => false,
+                        'version' => 1,
+                        'createdOn' => '2025-05-02T15:14:53+0000',
+                        'lastModifiedOn' => '2025-05-02T15:14:53+0000',
+                        'deletedDate' => null,
+                        'contactDetails' => null,
+                        'team' => null, // External user
+                    ],
+                    'lastModifiedBy' => null,
+                    'messagingContent' => [
+                        'id' => 1,
+                        'text' => 'Hello from Operator',
+                        'version' => 1,
+                        'createdOn' => '2023-11-06T12:12:12+0000',
+                        'lastModifiedOn' => null,
+                    ],
+                    'documents' => [],
+                ],
+                'Jane Caseworker',           // getSenderName()
+                '',                          // getFileList()
+                '',                          // getFirstReadBy()
+            ],
+            'internal_user_message_with_team' => [
+                [
+                    'id' => 2,
+                    'version' => 1,
+                    'createdOn' => '2025-01-15T10:00:00+00:00', // UTC in winter
+                    'lastModifiedOn' => null,
+                    'createdBy' => [
+                        'id' => 2,
+                        'team' => 'Licensing Team',
+                        'contactDetails' => null,
+                        'createdOn' => '2025-05-01T10:00:00+0000',
+                        'lastModifiedOn' => '2025-05-01T10:00:00+0000',
+                        'accountDisabled' => 'N',
+                        'version' => 1,
+                    ],
+                    'lastModifiedBy' => null,
+                    'messagingContent' => [
+                        'id' => 2,
+                        'text' => 'This is a caseworker message.',
+                        'version' => 1,
+                        'createdOn' => '2025-06-01T09:00:00+0000',
+                        'lastModifiedOn' => null,
+                    ],
+                    'documents' => [],
+                ],
+                'Alex Caseworker',          // getSenderName()
+                '',                         // getFileList()
+                '',                         // getFirstReadBy()
+            ],
+        ];
+    }
+}

--- a/test/Common/src/Common/Service/Table/Formatter/ExternalConversationLinkTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/ExternalConversationLinkTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace CommonTest\Common\Service\Table\Formatter;
+
+use Common\Service\Helper\UrlHelperService;
+use Common\Service\Table\Formatter\ExternalConversationLink;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * ExternalConversationLinkLink test
+ */
+class ExternalConversationLinkTest extends MockeryTestCase
+{
+    /** @var ExternalConversationLink */
+    private $sut;
+
+    /** @var m\MockInterface */
+    private $urlHelper;
+
+    protected function setUp(): void
+    {
+        $this->urlHelper = m::mock(UrlHelperService::class);
+        $this->sut = new ExternalConversationLink($this->urlHelper);
+        date_default_timezone_set('Europe/London');
+
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testExternalFormatSetsCreatedOnToDefaultTimezone(): void
+    {
+        $row = [
+            'id' => 1,
+            'userContextStatus' => 'NEW_MESSAGE',
+            'createdOn' => '2025-05-09T09:36:02+0000',
+            'subject' => 'Test Subject',
+            'task' => [
+                'licence' => ['licNo' => 'AB123'],
+            ],
+        ];
+
+        // Mock the URL helper
+        $this->urlHelper->expects('fromRoute')
+            ->with('conversations/view', ['conversationId' => 1])
+            ->andReturns('conversations/view');
+
+        $result = $this->sut->format($row);
+
+        // Extract date string from HTML output (it's after the <p> tag)
+        preg_match('/<p class="govuk-body govuk-!-margin-1">(.*?)<\/p>/', $result, $matches);
+        $formattedDateString = $matches[1];
+
+        $createdOn = '2025-05-09T09:36:02+0000';
+        $dateTime = \DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $createdOn)
+            ->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+
+        $expectedFormattedDate = $dateTime->format('l j F Y \a\t H:ia');
+
+        // Then assert the formatted datetime is included
+        $this->assertStringContainsString($expectedFormattedDate, $formattedDateString);
+    }
+}

--- a/test/Common/src/Common/Service/Table/Formatter/ExternalConversationLinkTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/ExternalConversationLinkTest.php
@@ -4,11 +4,9 @@ namespace CommonTest\Common\Service\Table\Formatter;
 
 use Common\Service\Helper\UrlHelperService;
 use Common\Service\Table\Formatter\ExternalConversationLink;
-use DateTimeImmutable;
 use DateTimeInterface;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
-use PHPUnit\Framework\TestCase;
 
 /**
  * ExternalConversationLinkLink test
@@ -26,7 +24,6 @@ class ExternalConversationLinkTest extends MockeryTestCase
         $this->urlHelper = m::mock(UrlHelperService::class);
         $this->sut = new ExternalConversationLink($this->urlHelper);
         date_default_timezone_set('Europe/London');
-
     }
 
     protected function tearDown(): void

--- a/test/Common/src/Common/Service/Table/Formatter/InternalConversationLinkTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/InternalConversationLinkTest.php
@@ -5,7 +5,6 @@ namespace CommonTest\Service\Table\Formatter;
 use Common\Service\Helper\UrlHelperService;
 use Common\Service\Table\Formatter\InternalConversationLink;
 use Common\Service\Table\Formatter\RefDataStatus;
-use DateTimeInterface;
 use Laminas\Router\Http\RouteMatch;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
@@ -138,7 +137,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                 'lva-application/conversation/view',
                 ['application' => 1000001, 'conversation' => 123],
                 '/application/1000001/conversation/123/',
-                '<a class="govuk-body govuk-link govuk-!-padding-right-1 govuk-!-font-weight-bold" href="/application/1000001/conversation/123/">OK2000001 / 1000001: Test Conversation 1</a><strong class="govuk-tag govuk-tag--red">New message</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 12:00pm</p>'
+                '<a class="govuk-body govuk-link govuk-!-padding-right-1 govuk-!-font-weight-bold" href="/application/1000001/conversation/123/">OK2000001 / 1000001: Test Conversation 1</a><strong class="govuk-tag govuk-tag--red">New message</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 13:00pm</p>'
             ],
             'licence_route' => [
                 'licence',
@@ -154,7 +153,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                 'licence/conversation/view',
                 ['licence' => 710, 'conversation' => 124],
                 '/licence/710/conversation/124/',
-                '<a class="govuk-body govuk-link govuk-!-padding-right-1 " href="/licence/710/conversation/124/">OK2000002: Test Conversation 2</a><strong class="govuk-tag govuk-tag--blue">Open</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 13:00pm</p>'
+                '<a class="govuk-body govuk-link govuk-!-padding-right-1 " href="/licence/710/conversation/124/">OK2000002: Test Conversation 2</a><strong class="govuk-tag govuk-tag--blue">Open</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 14:00pm</p>'
             ],
             'case_route' => [
                 'case',
@@ -171,7 +170,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                 'case_conversation/view',
                 ['licence' => 710, 'case' => 101, 'conversation' => 125],
                 '/case/101/conversation/125/',
-                '<a class="govuk-body govuk-link govuk-!-padding-right-1 " href="/case/101/conversation/125/">OK2000003: Test Conversation 3</a><strong class="govuk-tag govuk-tag--grey">Closed</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 14:00pm</p>'
+                '<a class="govuk-body govuk-link govuk-!-padding-right-1 " href="/case/101/conversation/125/">OK2000003: Test Conversation 3</a><strong class="govuk-tag govuk-tag--grey">Closed</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 15:00pm</p>'
             ],
             'busReg_route' => [
                 'busReg',
@@ -187,7 +186,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                 'licence/bus_conversation/view',
                 ['licence' => 710, 'busRegId' => 201, 'conversation' => 127],
                 '/licence/710/bus-registration/201/conversation/127/',
-                '<a class="govuk-body govuk-link govuk-!-padding-right-1 " href="/licence/710/bus-registration/201/conversation/127/">OK2000004: Test Conversation 4</a><strong class="govuk-tag govuk-tag--blue">Open</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 16:00pm</p>'
+                '<a class="govuk-body govuk-link govuk-!-padding-right-1 " href="/licence/710/bus-registration/201/conversation/127/">OK2000004: Test Conversation 4</a><strong class="govuk-tag govuk-tag--blue">Open</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 17:00pm</p>'
             ],
             'irhp-application_route' => [
                 'irhp-application',
@@ -203,7 +202,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                 'licence/irhp-application-conversation/view',
                 ['licence' => 710, 'irhpAppId' => 301, 'conversation' => 128],
                 '/licence/710/irhp-application/301/conversation/128/',
-                '<a class="govuk-body govuk-link govuk-!-padding-right-1 govuk-!-font-weight-bold" href="/licence/710/irhp-application/301/conversation/128/">OK2000005: Test Conversation 5</a><strong class="govuk-tag govuk-tag--red">New message</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 17:00pm</p>'
+                '<a class="govuk-body govuk-link govuk-!-padding-right-1 govuk-!-font-weight-bold" href="/licence/710/irhp-application/301/conversation/128/">OK2000005: Test Conversation 5</a><strong class="govuk-tag govuk-tag--red">New message</strong><br><p class="govuk-body govuk-!-margin-1">Saturday 12 August 2023 at 18:00pm</p>'
             ],
             'invalid_route' => [
                 'invalid',
@@ -227,7 +226,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                     'id' => 101,
                     'userContextStatus' => 'NEW_MESSAGE',
                     'subject' => 'Winter Test',
-                    'createdOn' => '2025-01-15T10:00:00+00:00', // UTC in winter
+                    'createdOn' => '2025-12-15T10:00:00+00:00', // UTC in winter
                     'task' => [
                         'application' => ['id' => 2001],
                         'licence' => ['id' => 1, 'licNo' => 'LIC001']
@@ -243,7 +242,7 @@ class InternalConversationLinkTest extends MockeryTestCase
                     'id' => 102,
                     'userContextStatus' => 'NEW_MESSAGE',
                     'subject' => 'Summer Test',
-                    'createdOn' => '2025-05-15T10:00:00+00:00', // Should convert to 11:00am in BST
+                    'createdOn' => '2023-05-15T10:00:00+00:00', // Should convert to 11:00am in BST
                     'task' => [
                         'application' => ['id' => 2002],
                         'licence' => ['id' => 1, 'licNo' => 'LIC002']

--- a/test/Common/src/Common/View/Helper/DateTimeTest.php
+++ b/test/Common/src/Common/View/Helper/DateTimeTest.php
@@ -22,15 +22,14 @@ class DateTimeTest extends MockeryTestCase
     protected function setUp(): void
     {
         $this->sut = new \Common\View\Helper\DateTime();
+
+        date_default_timezone_set('UTC');
     }
 
     /**
      * @dataProvider provider
-     *
-     * @param $format
-     * @param $expected
      */
-    public function testInvoke(\DateTime $dateTime, $format, $expected): void
+    public function testInvoke(\DateTime $dateTime, string $format, string $expected): void
     {
         $sut = $this->sut;
         $this->assertEquals($expected, $sut($dateTime, $format));
@@ -47,19 +46,19 @@ class DateTimeTest extends MockeryTestCase
     {
         return [
             [
-                new \DateTime('2016-06-10 12:00', new \DateTimeZone('UTC')),
+                new \DateTime('2016-06-11 12:00', new \DateTimeZone('UTC')),
                 'd/m/Y H:i',
-                '10/06/2016 12:00'
+                '11/06/2016 12:00'
             ],
             [
-                new \DateTime('2016-12-10 12:00', new \DateTimeZone('UTC')),
+                new \DateTime('2016-12-12 12:00', new \DateTimeZone('UTC')),
                 'd/m/Y H:i',
-                '10/12/2016 12:00'
+                '12/12/2016 12:00'
             ],
             [
-                new \DateTime('2016-06-10 12:00', new \DateTimeZone('Europe/London')),
+                new \DateTime('2016-06-13 12:00', new \DateTimeZone('Europe/London')),
                 'd/m/Y H:i',
-                '10/06/2016 11:00'
+                '13/06/2016 11:00'
             ],
         ];
     }


### PR DESCRIPTION
## Description

Self serve and internal messaging have been using the created on date directly from the database (UTC) without formatting the timezone with Europe/London to account for BST and winter clock changes. Created new tests for the changes and updated existing ones. 

Related issue: [VOL-6295](https://dvsa.atlassian.net/browse/VOL-6295)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?


[VOL-6295]: https://dvsa.atlassian.net/browse/VOL-6295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ