### PR TITLE
feat: vol-6098 removed laminas-serializer package and laminas-json from relevant code

### DIFF
--- a/Common/src/Common/Controller/Plugin/Redirect.php
+++ b/Common/src/Common/Controller/Plugin/Redirect.php
@@ -8,7 +8,6 @@
 
 namespace Common\Controller\Plugin;
 
-use Laminas\Json\Json;
 use Laminas\Mvc\Controller\Plugin\Redirect as LaminasRedirect;
 use Laminas\Stdlib\ArrayUtils;
 
@@ -61,7 +60,7 @@ class Redirect extends LaminasRedirect
                 'location' => $controller->url()->fromRoute($route, $params, $options, $reuseMatchedParams)
             ];
             $this->getResponse()->getHeaders()->addHeaders(['Content-Type' => 'application/json']);
-            $this->getResponse()->setContent(Json::encode($data));
+            $this->getResponse()->setContent(json_encode($data));
             return $this->getResponse();
         }
         return $this->toRoute($route, $params, $options, $reuseMatchedParams);

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,6 @@
         "bamarni/composer-bin-plugin": "^1.8",
         "doctrine/annotations": "^1.14.2",
         "johnkary/phpunit-speedtrap": "^4.0",
-        "laminas/laminas-serializer": "^2.10",
         "lm-commons/lmc-rbac-mvc": "^3.3",
         "mikey179/vfsstream": "~v1.6.11",
         "mockery/mockery": "^1.6.7",


### PR DESCRIPTION
This PR removes the deprecated laminas-json and laminas-serializer packages and replaces their usage with native PHP json_encode() and json_decode() functions. This change is driven by Laminas abandoning these legacy libraries as announced by their technical steering committee.

- Remove laminas/laminas-serializer dependencies from composer.json files
- Replaces Laminas JSON serialization/deserialization with native PHP JSON functions

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2024-11-04-TSC-Minutes.md#archive--abandon-various-legacy-libraries

Related issue: [VOL-6098](https://dvsa.atlassian.net/browse/VOL-6098)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6098]: https://dvsa.atlassian.net/browse/VOL-6098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ