### PR TITLE
feat: filter documents by current application

### DIFF
--- a/Common/src/Common/Controller/Lva/AbstractOperatingCentresController.php
+++ b/Common/src/Common/Controller/Lva/AbstractOperatingCentresController.php
@@ -356,7 +356,11 @@ abstract class AbstractOperatingCentresController extends AbstractController
 
         $resultData = $this->fetchOcItemData();
 
-        $this->documents = $resultData['operatingCentre']['adDocuments'];
+        $this->documents = array_filter(
+            $resultData['operatingCentre']['adDocuments'],
+            fn($doc) => isset($doc['application']['id']) && $doc['application']['id'] === $this->getIdentifier()
+        );
+
         // need to store the operating centre ID so that uploaded documents can be attached
         $this->operatingCentreId = $resultData['operatingCentre']['id'];
 


### PR DESCRIPTION
## Description
The bug was showing documents that were uploaded against an operating centre on the original application. This fix filters out documents so that only those uploaded for the current application or variation are shown.

Related issue: [VOL-6575](https://dvsa.atlassian.net/browse/VOL-6575)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
