### PR TITLE
chore: bumped olcs-transfer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "laminas/laminas-validator": "^2.64",
         "laminas/laminas-view": "^2.41",
         "olcs/olcs-logging": "^7.2 || ^8.0",
-        "olcs/olcs-transfer": "^7.18 || ^8.0",
+        "olcs/olcs-transfer": "8.0.2",
         "olcs/olcs-utils": "^6.0 || ^7.0",
         "psr/container": "^1.1|^2"
     },


### PR DESCRIPTION
## Description

Bumping the version for olcs-transfer to include the work to remove legacy TransXChange code

Related issue: [VOL-5649](https://dvsa.atlassian.net/browse/VOL-5649)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5649]: https://dvsa.atlassian.net/browse/VOL-5649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ