### PR TITLE
feat: vol 6119 remove post references from continuation journey wording

### DIFF
--- a/Common/config/language/partials/en_GB/bullets/markup-undertakings-gv-common.phtml
+++ b/Common/config/language/partials/en_GB/bullets/markup-undertakings-gv-common.phtml
@@ -1,5 +1,4 @@
-  <li>The laws relating to the driving and operation of vehicles used under this
-  licence are observed;</li>
+  <li>The laws relating to the driving and operation of vehicles and trailers used under the licence are observed;</li>
 
   <li>The rules on drivers’ hours and tachographs are observed and proper records are kept, and that these are made available on request;</li>
 
@@ -17,6 +16,8 @@
   <li>Records are kept (for at least 15 months) of all driver reports which record defects, all
   safety inspections, routine maintenance and repairs to vehicles, and that these
   are made available on request;</li>
+
+  <li>An unauthorised operating centre is not used in any traffic area;</li>
 
   <li>In respect of each operating centre specified, that the number of vehicles and
   the number of trailers kept there will not exceed the maximum numbers authorised

--- a/Common/config/language/partials/en_GB/bullets/markup-undertakings-gvni-common.phtml
+++ b/Common/config/language/partials/en_GB/bullets/markup-undertakings-gvni-common.phtml
@@ -18,6 +18,8 @@
   safety inspections, routine maintenance and repairs to vehicles, and that these
   are made available on request;</li>
 
+  <li>An unauthorised operating centre is not used in any traffic area;</li>
+
   <li>In respect of each operating centre specified, that the number of vehicles and
   the number of trailers kept there will not exceed the maximum numbers authorised
   at each operating centre (which will be noted on the licence);</li>

--- a/Common/config/language/partials/en_GB/markup-continuation-financial-evidence-required-hint.phtml
+++ b/Common/config/language/partials/en_GB/markup-continuation-financial-evidence-required-hint.phtml
@@ -1,1 +1,1 @@
-You need to send us information about your finances. You can either upload or post a copy to us. See the <?php echo $this->linkNewWindow($this->url('guides/guide', ['guide' => 'financial-evidence']), 'types of evidence we accept'); ?>.
+You need to send us information about your finances. You can either upload or use VOL messaging later. See the <?php echo $this->linkNewWindow($this->url('guides/guide', ['guide' => 'financial-evidence']), 'types of evidence we accept'); ?>.


### PR DESCRIPTION
## Description

Removed post references from continuation journey wording.

Related issue: [VOL-6119](https://dvsa.atlassian.net/browse/VOL-6119)

Dependencies: [OLCS-ETL #132](https://github.com/dvsa/olcs-etl/pull/132)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6119]: https://dvsa.atlassian.net/browse/VOL-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ