### PR TITLE
feat: swapped olcs-logging from laminas-log to monolog VOL-6099

### DIFF
--- a/Common/config/module.config.php
+++ b/Common/config/module.config.php
@@ -160,7 +160,6 @@ return [
             'Cache' => \Laminas\Cache\Storage\StorageInterface::class,
             'DataServiceManager' => \Common\Service\Data\PluginManager::class,
             'translator' => 'MvcTranslator',
-            'Laminas\Log' => 'Logger',
             'TableBuilder' => \Common\Service\Table\TableBuilderFactory::class,
             'NavigationFactory' => \Common\Service\NavigationFactory::class,
             'QueryService' => \Common\Service\Cqrs\Query\CachingQueryService::class,

--- a/Common/src/Common/Service/Cqrs/Query/CachingQueryService.php
+++ b/Common/src/Common/Service/Cqrs/Query/CachingQueryService.php
@@ -17,9 +17,9 @@ use Dvsa\Olcs\Transfer\Util\Annotation\AnnotationBuilder;
  * Class CachingQueryService
  * @package Common\Service\Cqrs\Query
  */
-class CachingQueryService implements QueryServiceInterface, \Laminas\Log\LoggerAwareInterface
+class CachingQueryService implements QueryServiceInterface, \Psr\Log\LoggerAwareInterface
 {
-    use \Laminas\Log\LoggerAwareTrait;
+    use \Psr\Log\LoggerAwareTrait;
     use RecoverHttpClientExceptionTrait;
 
     public const BACKEND_FAIL_MSG = 'Backend DB failure HTTP code: %s';
@@ -310,8 +310,8 @@ class CachingQueryService implements QueryServiceInterface, \Laminas\Log\LoggerA
      */
     private function logMessage($message): void
     {
-        if ($this->getLogger()) {
-            $this->getLogger()->debug($message);
+        if ($this->logger) {
+            $this->logger->debug($message);
         }
     }
 
@@ -322,8 +322,8 @@ class CachingQueryService implements QueryServiceInterface, \Laminas\Log\LoggerA
      */
     private function logError(string $error): void
     {
-        if ($this->getLogger()) {
-            $this->getLogger()->err($error);
+        if ($this->logger) {
+            $this->logger->error($error);
         }
     }
 }

--- a/Common/src/Common/Service/Cqrs/RequestFactory.php
+++ b/Common/src/Common/Service/Cqrs/RequestFactory.php
@@ -21,8 +21,7 @@ class RequestFactory implements FactoryInterface
         $contentType = new ContentType();
         $contentType->setMediaType('application/json');
 
-        $identifier = $container->get('LogProcessorManager')->get(\Olcs\Logging\Log\Processor\RequestId::class)
-            ->getIdentifier();
+        $identifier = $container->get(\Olcs\Logging\Log\Processor\RequestId::class)->getIdentifier();
         $correlationHeader = new \Laminas\Http\Header\GenericHeader('X-Correlation-Id', $identifier);
 
         $headers = new Headers();

--- a/Common/src/Module.php
+++ b/Common/src/Module.php
@@ -114,9 +114,7 @@ class Module implements ConfigProviderInterface, ServiceProviderInterface
 
         $this->setLoggerUser($sm);
 
-        $identifier = $sm->get('LogProcessorManager')
-            ->get(\Olcs\Logging\Log\Processor\RequestId::class)
-            ->getIdentifier();
+        $identifier = $sm->get(\Olcs\Logging\Log\Processor\RequestId::class)->getIdentifier();
 
         $this->onFatalError($identifier);
 
@@ -305,7 +303,7 @@ class Module implements ConfigProviderInterface, ServiceProviderInterface
     private function setLoggerUser(ServiceManager $serviceManager): void
     {
         $authService = $serviceManager->get(\LmcRbacMvc\Service\AuthorizationService::class);
-        $serviceManager->get('LogProcessorManager')->get(\Olcs\Logging\Log\Processor\UserId::class)
+        $serviceManager->get(\Olcs\Logging\Log\Processor\UserId::class)
             ->setUserId($authService->getIdentity()->getUsername());
     }
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Common library for the OLCS Project",
     "type": "library",
     "require": {
-        "php": "~8.2.0 || ~8.3.0",
+        "php": "~8.3.0",
         "ezyang/htmlpurifier": "^4.17",
         "laminas/laminas-authentication": "^2.18",
         "laminas/laminas-cache": "^3.13",
@@ -24,9 +24,9 @@
         "laminas/laminas-text": "^2.12",
         "laminas/laminas-validator": "^2.64",
         "laminas/laminas-view": "^2.41",
-        "olcs/olcs-logging": "^7.2 || ^8.0",
+        "olcs/olcs-logging": "^9.0",
         "olcs/olcs-transfer": "^8.0",
-        "olcs/olcs-utils": "^6.0 || ^7.0",
+        "olcs/olcs-utils": "^7.1",
         "psr/container": "^1.1|^2"
     },
     "require-dev": {

--- a/test/Common/src/Common/Service/Cqrs/Query/CachingQueryServiceFactoryTest.php
+++ b/test/Common/src/Common/Service/Cqrs/Query/CachingQueryServiceFactoryTest.php
@@ -26,7 +26,7 @@ class CachingQueryServiceFactoryTest extends MockeryTestCase
 
         $mockSl = m::mock(ContainerInterface::class);
         $mockSl->shouldReceive('get')->with('Config')->andReturn($config);
-        $mockSl->shouldReceive('get')->with('Logger')->andReturn(m::mock(\Laminas\Log\LoggerInterface::class));
+        $mockSl->shouldReceive('get')->with('Logger')->andReturn(m::mock(\Psr\Log\LoggerInterface::class));
         $mockSl->shouldReceive('get')->with('TransferAnnotationBuilder')->andReturn(m::mock(AnnotationBuilder::class));
         $mockSl->shouldReceive('get')->with(QueryService::class)->andReturn(m::mock(QueryService::class));
         $mockSl->shouldReceive('get')->with(CacheEncryption::class)->andReturn(m::mock(CacheEncryption::class));

--- a/test/Common/src/Common/Service/Cqrs/Query/CachingQueryServiceTest.php
+++ b/test/Common/src/Common/Service/Cqrs/Query/CachingQueryServiceTest.php
@@ -229,10 +229,10 @@ class CachingQueryServiceTest extends MockeryTestCase
         $mockCache = m::mock(CacheEncryptionService::class);
         $mockCache->expects('hasItem')->with('cache_key', 'encryption_mode')->andReturnFalse();
 
-        $mockLogger = m::mock(\Laminas\Log\LoggerInterface::class);
+        $mockLogger = m::mock(\Psr\Log\LoggerInterface::class);
         $mockLogger->expects('debug')->with('Using encryption mode: encryption_mode')->ordered();
         $mockLogger->expects('debug')->with('Storing in local cache: dto_class_name')->ordered();
-        $mockLogger->expects('err')->with('Cache failure: No TTL value found for this query')->ordered();
+        $mockLogger->expects('error')->with('Cache failure: No TTL value found for this query')->ordered();
 
         $sut = new CachingQueryService($mockQS, $mockCache, $this->mockAnnotationBuilder, true, $this->ttlValues());
         $sut->setLogger($mockLogger);
@@ -270,7 +270,7 @@ class CachingQueryServiceTest extends MockeryTestCase
         $mockCache->expects('hasItem')->with('cache_key', 'encryption_mode')->andReturnFalse();
         $mockCache->expects('setItem')->with('cache_key', 'encryption_mode', $this->mockResult, $cacheTtl)->andReturn();
 
-        $mockLogger = m::mock(\Laminas\Log\LoggerInterface::class);
+        $mockLogger = m::mock(\Psr\Log\LoggerInterface::class);
         $mockLogger->expects('debug')->with('Using encryption mode: encryption_mode')->ordered();
         $mockLogger->expects('debug')->with('Storing in local cache: dto_class_name')->ordered();
         $mockLogger->expects('debug')->with('Storing in persistent cache with TTL of ' . $cacheTtl . ' seconds: dto_class_name')->ordered();
@@ -324,7 +324,7 @@ class CachingQueryServiceTest extends MockeryTestCase
         $mockCache->expects('hasItem')->with('cache_key', 'encryption_mode')->andReturnTrue();
         $mockCache->expects('getItem')->with('cache_key', true)->andReturn($this->mockResult);
 
-        $mockLogger = m::mock(\Laminas\Log\LoggerInterface::class);
+        $mockLogger = m::mock(\Psr\Log\LoggerInterface::class);
         $mockLogger->expects('debug')->with('Using encryption mode: encryption_mode')->ordered();
         $mockLogger->expects('debug')->with('Fetching from persistent cache: dto_class_name')->ordered();
         $mockLogger->expects('debug')->with('Storing in local cache: dto_class_name')->ordered();
@@ -361,10 +361,10 @@ class CachingQueryServiceTest extends MockeryTestCase
         $mockCache->expects('hasItem')->with('cache_key', 'encryption_mode')->andReturnTrue();
         $mockCache->expects('getItem')->with('cache_key', true)->andThrow(new \Exception('exception_msg'));
 
-        $mockLogger = m::mock(\Laminas\Log\LoggerInterface::class);
+        $mockLogger = m::mock(\Psr\Log\LoggerInterface::class);
         $mockLogger->expects('debug')->with('Using encryption mode: encryption_mode')->ordered();
         $mockLogger->expects('debug')->with('Fetching from persistent cache: dto_class_name')->ordered();
-        $mockLogger->expects('err')->with('Cache failure: exception_msg')->ordered();
+        $mockLogger->expects('error')->with('Cache failure: exception_msg')->ordered();
 
         $sut = new CachingQueryService($mockQS, $mockCache, $this->mockAnnotationBuilder, true, $this->ttlValues());
         $sut->setLogger($mockLogger);

--- a/test/Common/src/Common/Service/Cqrs/RequestFactoryTest.php
+++ b/test/Common/src/Common/Service/Cqrs/RequestFactoryTest.php
@@ -3,11 +3,11 @@
 namespace CommonTest\Service\Cqrs;
 
 use Common\Service\Cqrs\RequestFactory;
-use Psr\Container\ContainerInterface;
-use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
-use Mockery as m;
 use Laminas\Http\Request;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase as TestCase;
 use Olcs\Logging\Log\Processor\RequestId;
+use Psr\Container\ContainerInterface;
 
 class RequestFactoryTest extends TestCase
 {
@@ -15,17 +15,16 @@ class RequestFactoryTest extends TestCase
     {
         $cookies = [];
 
-        $mockLogProcessor = m::mock();
-        $mockLogProcessor->expects('get')->with(RequestId::class)->andReturn(
-            m::mock()->shouldReceive('getIdentifier')->with()->once()->andReturn('IDENT1')->getMock()
-        );
+        $mockRequestId = m::mock(RequestId::class);
+        $mockRequestId->shouldReceive('getIdentifier')->withNoArgs()->once()->andReturn('IDENT1');
 
         $mockRequest = m::mock(Request::class);
         $mockRequest->shouldReceive('getCookie')->andReturn($cookies);
 
         $mockSl = m::mock(ContainerInterface::class);
         $mockSl->shouldReceive('get')->with('Request')->andReturn($mockRequest);
-        $mockSl->shouldReceive('get')->with('LogProcessorManager')->andReturn($mockLogProcessor);
+        $mockSl->shouldReceive('get')->with(RequestId::class)->andReturn($mockRequestId);
+
         $sut = new RequestFactory();
         $service = $sut->__invoke($mockSl, Request::class);
 
@@ -44,17 +43,16 @@ class RequestFactoryTest extends TestCase
     {
         $cookies = ['secureToken' => 'myToken'];
 
-        $mockLogProcessor = m::mock();
-        $mockLogProcessor->expects('get')->with(RequestId::class)->andReturn(
-            m::mock()->shouldReceive('getIdentifier')->with()->once()->andReturn('IDENT1')->getMock()
-        );
+        $mockRequestId = m::mock(RequestId::class);
+        $mockRequestId->shouldReceive('getIdentifier')->withNoArgs()->once()->andReturn('IDENT1');
 
         $mockRequest = m::mock(Request::class);
         $mockRequest->shouldReceive('getCookie')->andReturn($cookies);
 
         $mockSl = m::mock(ContainerInterface::class);
         $mockSl->shouldReceive('get')->with('Request')->andReturn($mockRequest);
-        $mockSl->shouldReceive('get')->with('LogProcessorManager')->andReturn($mockLogProcessor);
+        $mockSl->shouldReceive('get')->with(RequestId::class)->andReturn($mockRequestId);
+
         $sut = new RequestFactory();
         $service = $sut->__invoke($mockSl, Request::class);
 

--- a/test/Common/src/Common/Service/Helper/FileUploadHelperServiceTest.php
+++ b/test/Common/src/Common/Service/Helper/FileUploadHelperServiceTest.php
@@ -697,10 +697,6 @@ class FileUploadHelperServiceTest extends MockeryTestCase
 
     public static function setupLogger(): void
     {
-        $logWriter = new \Laminas\Log\Writer\Mock();
-        $logger = new \Laminas\Log\Logger();
-        $logger->addWriter($logWriter);
-
-        Logger::setLogger($logger);
+        Logger::setLogger(new \Psr\Log\NullLogger());
     }
 }

--- a/test/Common/src/Common/Service/Translator/TranslationLoaderTest.php
+++ b/test/Common/src/Common/Service/Translator/TranslationLoaderTest.php
@@ -108,10 +108,6 @@ class TranslationLoaderTest extends MockeryTestCase
 
     public static function setupLogger(): void
     {
-        $logWriter = new \Laminas\Log\Writer\Mock();
-        $logger = new \Laminas\Log\Logger();
-        $logger->addWriter($logWriter);
-
-        Logger::setLogger($logger);
+        Logger::setLogger(new \Psr\Log\NullLogger());
     }
 }


### PR DESCRIPTION
## Description

Compatibility with the new monolog based olcs-logging library (laminas-log removed)

Related issue: [VOL-6099](https://dvsa.atlassian.net/browse/VOL-6099)

Note pipeline failures are pre existing and are being dealt with in [VOL-6800](https://dvsa.atlassian.net/browse/VOL-6800)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6099]: https://dvsa.atlassian.net/browse/VOL-6099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[VOL-6800]: https://dvsa.atlassian.net/browse/VOL-6800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ