### PR TITLE
fix: vol 5399 guidance error render bug

### DIFF
--- a/Common/src/Common/Data/Mapper/Lva/OperatingCentre.php
+++ b/Common/src/Common/Data/Mapper/Lva/OperatingCentre.php
@@ -202,6 +202,7 @@ class OperatingCentre implements MapperInterface
                 foreach ($message as $k => $v) {
                     if ($k === 'ERR_OC_PC_TA_GB') {
                         $message[$k] = $translator->translateReplace($k, [$taGuidesUrl]);
+                        $form->get('form-actions')->setOption('shouldEscapeMessages', false);
                         self::setConfirmation($form, $translator, $isExternal, $k);
                     } elseif (in_array($k, OperatingCentres::API_ERR_KEYS)) {
                         $message[$k] = $translator->translateReplace($k . '_' . strtoupper($location), [$v]);

--- a/test/Common/src/Common/Data/Mapper/Lva/OperatingCentreTest.php
+++ b/test/Common/src/Common/Data/Mapper/Lva/OperatingCentreTest.php
@@ -240,6 +240,10 @@ class OperatingCentreTest extends MockeryTestCase
             'cake' => 'bar'
         ];
 
+        $formActions = m::mock();
+        $formActions->shouldReceive('setOption')->once()->with('shouldEscapeMessages', false);
+        $form->shouldReceive('get')->once()->with('form-actions')->andReturn($formActions);
+
         $form->shouldReceive('setMessages')
             ->once()
             ->with($expectedMessages);
@@ -331,8 +335,14 @@ class OperatingCentreTest extends MockeryTestCase
         if ($location === OperatingCentre::LOC_INTERNAL) {
             $mockTranslatorService->shouldReceive('translate')->with('ERR_OC_PC_TA_GB-confirm')->once();
             $mockTranslatorService->shouldReceive('translate')->with('ERR_OC_PC_TA_GB-internalwarning')->once();
-            $form->shouldReceive('get')->once()->andReturnSelf();
-            $form->shouldReceive('add')->once();
+            $mockFormActions = m::mock();
+            $mockFormActions->shouldReceive('setOption')->once()->with('shouldEscapeMessages', false);
+            $mockFormActions->shouldReceive('add')->once();
+            $form->shouldReceive('get')->with('form-actions')->twice()->andReturn($mockFormActions);
+        } else {
+            $mockFormActions = m::mock();
+            $mockFormActions->shouldReceive('setOption')->once()->with('shouldEscapeMessages', false);
+            $form->shouldReceive('get')->once()->with('form-actions')->andReturn($mockFormActions);
         }
 
         $form->shouldReceive('setMessages')->once()->with($expected);

--- a/test/Common/src/Common/Data/Mapper/Lva/OperatingCentreTest.php
+++ b/test/Common/src/Common/Data/Mapper/Lva/OperatingCentreTest.php
@@ -240,7 +240,7 @@ class OperatingCentreTest extends MockeryTestCase
             'cake' => 'bar'
         ];
 
-        $formActions = m::mock();
+        $formActions = m::mock(\Laminas\Form\ElementInterface::class);
         $formActions->shouldReceive('setOption')->once()->with('shouldEscapeMessages', false);
         $form->shouldReceive('get')->once()->with('form-actions')->andReturn($formActions);
 
@@ -335,12 +335,12 @@ class OperatingCentreTest extends MockeryTestCase
         if ($location === OperatingCentre::LOC_INTERNAL) {
             $mockTranslatorService->shouldReceive('translate')->with('ERR_OC_PC_TA_GB-confirm')->once();
             $mockTranslatorService->shouldReceive('translate')->with('ERR_OC_PC_TA_GB-internalwarning')->once();
-            $mockFormActions = m::mock();
+            $mockFormActions = m::mock(\Laminas\Form\ElementInterface::class);
             $mockFormActions->shouldReceive('setOption')->once()->with('shouldEscapeMessages', false);
             $mockFormActions->shouldReceive('add')->once();
             $form->shouldReceive('get')->with('form-actions')->twice()->andReturn($mockFormActions);
         } else {
-            $mockFormActions = m::mock();
+            $mockFormActions = m::mock(\Laminas\Form\ElementInterface::class);
             $mockFormActions->shouldReceive('setOption')->once()->with('shouldEscapeMessages', false);
             $form->shouldReceive('get')->once()->with('form-actions')->andReturn($mockFormActions);
         }


### PR DESCRIPTION
## Description

Fix rendering of traffic area error message link on operating centre add/edit pages. The translated error message contains an HTML anchor tag which was being escaped by FormElementErrors, causing it to display as raw text rather than a clickable link. 

Related issue: [VOL-5399](https://dvsa.atlassian.net/browse/VOL-5399)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5399]: https://dvsa.atlassian.net/browse/VOL-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ