### PR TITLE
fix: vol 5811 error message is displayed twice on the safety and compliance page

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/SafetyLicence.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/SafetyLicence.php
@@ -92,7 +92,6 @@ class SafetyLicence
      *          "context_field": "tachographIns",
      *          "context_values": {"tach_external"},
      *          "validators": {
-     *              {"name": "NotEmpty"},
      *              {"name": "StringLength", "options": {"min":"1","max":90}}
      *          }
      *     }


### PR DESCRIPTION
## Description

Removed duplicate validator that was causing duplicate error messages.

Related issue: [VOL-5811](https://dvsa.atlassian.net/browse/VOL-5811)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5811]: https://dvsa.atlassian.net/browse/VOL-5811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ