### PR TITLE
feat: removed dependency on laminas-mvc-plugin-prg VOL-7230

### DIFF
--- a/Common/config/module.config.php
+++ b/Common/config/module.config.php
@@ -102,13 +102,9 @@ return [
         ]
     ],
     'controller_plugins' => [
-        'aliases' => [
-          'prg' => \Laminas\Mvc\Plugin\Prg\PostRedirectGet::class
-        ],
         'invokables' => [
             'redirect' => \Common\Controller\Plugin\Redirect::class,
             \Common\Controller\Plugin\Redirect::class => \Common\Controller\Plugin\Redirect::class,
-            \Laminas\Mvc\Plugin\Prg\PostRedirectGet::class => \Laminas\Mvc\Plugin\Prg\PostRedirectGet::class
         ],
         'factories' => [
             'currentUser' => \Common\Controller\Plugin\CurrentUserFactory::class,

--- a/Common/src/Common/Controller/Lva/Application/AbstractTypeOfLicenceController.php
+++ b/Common/src/Common/Controller/Lva/Application/AbstractTypeOfLicenceController.php
@@ -3,6 +3,7 @@
 namespace Common\Controller\Lva\Application;
 
 use Common\Controller\Lva;
+use Common\Controller\Traits\PostRedirectGetTrait;
 use Common\Data\Mapper\Lva\TypeOfLicence as TypeOfLicenceMapper;
 use Common\FormService\Form\Lva\TypeOfLicence\AbstractTypeOfLicence as TypeOfLicenceFormService;
 use Common\FormService\FormServiceManager;
@@ -22,6 +23,8 @@ use LmcRbacMvc\Service\AuthorizationService;
  */
 abstract class AbstractTypeOfLicenceController extends Lva\AbstractTypeOfLicenceController
 {
+    use PostRedirectGetTrait;
+
     public function __construct(
         NiTextTranslation $niTextTranslationUtil,
         AuthorizationService $authService,

--- a/Common/src/Common/Controller/Lva/Variation/AbstractTypeOfLicenceController.php
+++ b/Common/src/Common/Controller/Lva/Variation/AbstractTypeOfLicenceController.php
@@ -3,6 +3,7 @@
 namespace Common\Controller\Lva\Variation;
 
 use Common\Controller\Lva;
+use Common\Controller\Traits\PostRedirectGetTrait;
 use Common\Data\Mapper\Lva\TypeOfLicence as TypeOfLicenceMapper;
 use Common\FormService\FormServiceManager;
 use Common\Service\Helper\FlashMessengerHelperService;
@@ -21,6 +22,8 @@ use LmcRbacMvc\Service\AuthorizationService;
  */
 abstract class AbstractTypeOfLicenceController extends Lva\AbstractTypeOfLicenceController
 {
+    use PostRedirectGetTrait;
+
     public function __construct(
         NiTextTranslation $niTextTranslationUtil,
         AuthorizationService $authService,

--- a/Common/src/Common/Controller/Traits/PostRedirectGetTrait.php
+++ b/Common/src/Common/Controller/Traits/PostRedirectGetTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Common\Controller\Traits;
+
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\Controller\Plugin\Params;
+use Laminas\Mvc\Controller\Plugin\Redirect;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Session\Container;
+
+/**
+ * Manual Post-Redirect-Get implementation used by controllers that previously
+ * relied on the discontinued `laminas-mvc-plugin-prg`. Behaves identically:
+ *
+ *  - On POST: stores submitted data in a session container keyed by the
+ *    request URI (1-hop expiration) and returns a 303 redirect to the current
+ *    route. Caller should return this Response.
+ *  - On GET with previously-stored data: returns the data array and clears
+ *    the container.
+ *  - On GET with no stored data: returns false.
+ *
+ * @method Redirect redirect()
+ * @method Params params()
+ * @method MvcEvent getEvent()
+ * @method Request getRequest()
+ */
+trait PostRedirectGetTrait
+{
+    private ?Container $prgSessionContainer = null;
+
+    /**
+     * @return Response|array<string, mixed>|false
+     */
+    public function prg(): Response|array|false
+    {
+        /** @var Request $request */
+        $request = $this->getRequest();
+        $container = $this->getPrgSessionContainer($request);
+
+        if ($request->isPost()) {
+            $container->setExpirationHops(1, 'post');
+            $container->offsetSet('post', $request->getPost()->toArray());
+
+            $routeMatch = $this->getEvent()->getRouteMatch();
+            $response = $this->redirect()->toRoute(
+                $routeMatch->getMatchedRouteName(),
+                [],
+                ['query' => $this->params()->fromQuery()],
+                true,
+            );
+            $response->setStatusCode(303);
+            return $response;
+        }
+
+        if ($container->offsetExists('post')) {
+            $post = $container->offsetGet('post');
+            $container->offsetUnset('post');
+            return $post;
+        }
+
+        return false;
+    }
+
+    /**
+     * Visible to tests so they can inject a pre-seeded container.
+     */
+    public function setPrgSessionContainer(Container $container): void
+    {
+        $this->prgSessionContainer = $container;
+    }
+
+    private function getPrgSessionContainer(Request $request): Container
+    {
+        if ($this->prgSessionContainer === null) {
+            $this->prgSessionContainer = new Container(md5((string) $request->getUri()));
+        }
+        return $this->prgSessionContainer;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "laminas/laminas-modulemanager": "^2.17",
         "laminas/laminas-mvc": "^3.8",
         "laminas/laminas-mvc-plugin-flashmessenger": "^1.11",
-        "laminas/laminas-mvc-plugin-prg": "^1.8",
         "laminas/laminas-navigation": "^2.20",
         "laminas/laminas-servicemanager": "^3.23",
         "laminas/laminas-stdlib": "^3.20",

--- a/test/Common/src/Common/Controller/Traits/PostRedirectGetTraitTest.php
+++ b/test/Common/src/Common/Controller/Traits/PostRedirectGetTraitTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CommonTest\Common\Controller\Traits;
+
+use Common\Controller\Traits\PostRedirectGetTrait;
+use Laminas\Http\Request;
+use Laminas\Http\Response;
+use Laminas\Mvc\Controller\Plugin\Params;
+use Laminas\Mvc\Controller\Plugin\Redirect;
+use Laminas\Mvc\MvcEvent;
+use Laminas\Router\RouteMatch;
+use Laminas\Session\Container;
+use Laminas\Stdlib\Parameters;
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class PostRedirectGetTraitTest extends MockeryTestCase
+{
+    private Container $container;
+
+    /**
+     * @var object
+     */
+    private $sut;
+
+    private Request $request;
+
+    private m\MockInterface $redirect;
+
+    private m\MockInterface $params;
+
+    private m\MockInterface $mvcEvent;
+
+    private RouteMatch $routeMatch;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->container = new Container('test_prg');
+        $this->container->offsetUnset('post');
+
+        $this->request = new Request();
+        $this->request->setUri('https://example.test/some/path');
+
+        $this->redirect = m::mock(Redirect::class);
+        $this->params = m::mock(Params::class);
+        $this->routeMatch = new RouteMatch([]);
+        $this->routeMatch->setMatchedRouteName('some/route');
+
+        $this->mvcEvent = m::mock(MvcEvent::class);
+
+        $this->sut = new class ($this->request, $this->redirect, $this->params, $this->mvcEvent) {
+            use PostRedirectGetTrait;
+
+            public function __construct(
+                private Request $request,
+                private $redirect,
+                private $params,
+                private MvcEvent $event,
+            ) {
+            }
+
+            public function getRequest(): Request
+            {
+                return $this->request;
+            }
+
+            public function redirect()
+            {
+                return $this->redirect;
+            }
+
+            public function params()
+            {
+                return $this->params;
+            }
+
+            public function getEvent(): MvcEvent
+            {
+                return $this->event;
+            }
+        };
+
+        $this->sut->setPrgSessionContainer($this->container);
+    }
+
+    public function testPostStoresDataAndReturns303Redirect(): void
+    {
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->setPost(new Parameters(['field' => 'value']));
+
+        $this->mvcEvent->expects('getRouteMatch')->withNoArgs()->andReturn($this->routeMatch);
+        $this->params->expects('fromQuery')->withNoArgs()->andReturn(['q' => 'x']);
+
+        $response = new Response();
+        $this->redirect
+            ->expects('toRoute')
+            ->with('some/route', [], ['query' => ['q' => 'x']], true)
+            ->andReturn($response);
+
+        $result = $this->sut->prg();
+
+        $this->assertSame($response, $result);
+        $this->assertSame(303, $result->getStatusCode());
+        $this->assertEquals(['field' => 'value'], $this->container->offsetGet('post'));
+    }
+
+    public function testGetWithStoredDataReturnsArrayAndClearsContainer(): void
+    {
+        $this->container->offsetSet('post', ['field' => 'value']);
+        $this->request->setMethod(Request::METHOD_GET);
+
+        $result = $this->sut->prg();
+
+        $this->assertEquals(['field' => 'value'], $result);
+        $this->assertFalse($this->container->offsetExists('post'));
+    }
+
+    public function testGetWithoutStoredDataReturnsFalse(): void
+    {
+        $this->request->setMethod(Request::METHOD_GET);
+
+        $this->assertFalse($this->sut->prg());
+    }
+
+    public function testFullPostRedirectGetRoundTrip(): void
+    {
+        // POST stores data and redirects
+        $this->request->setMethod(Request::METHOD_POST);
+        $this->request->setPost(new Parameters(['name' => 'alice']));
+        $this->mvcEvent->expects('getRouteMatch')->withNoArgs()->andReturn($this->routeMatch);
+        $this->params->expects('fromQuery')->withNoArgs()->andReturn([]);
+        $this->redirect
+            ->expects('toRoute')
+            ->with('some/route', [], ['query' => []], true)
+            ->andReturn(new Response());
+
+        $postResult = $this->sut->prg();
+
+        $this->assertInstanceOf(Response::class, $postResult);
+        $this->assertEquals(['name' => 'alice'], $this->container->offsetGet('post'));
+
+        // GET replay returns the stored data
+        $this->request->setMethod(Request::METHOD_GET);
+        $this->request->setPost(new Parameters([]));
+
+        $getResult = $this->sut->prg();
+
+        $this->assertEquals(['name' => 'alice'], $getResult);
+        $this->assertFalse($this->container->offsetExists('post'));
+    }
+}


### PR DESCRIPTION
## Description

Replaces the abandoned laminas-mvc-plugin-prg. We didn't do a straight swap for our own controller plugin, because they disappear too once laminas-mvc is removed from the codebase.

We do still use Laminas/Mvc imports but only in the method annotations. At some point those will also need to change.

Related issue: [VOL-7230](https://dvsa.atlassian.net/browse/VOL-7230)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-7230]: https://dvsa.atlassian.net/browse/VOL-7230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ