### PR TITLE
fix: tolerate E_USER_ERROR in onFatalError so user journeys continue

### DIFF
--- a/Common/src/Module.php
+++ b/Common/src/Module.php
@@ -151,8 +151,11 @@ class Module implements ConfigProviderInterface, ServiceProviderInterface
             static function () use ($identifier) {
                 // get error
                 $error = error_get_last();
+                // E_USER_ERROR included: vendor __toString fallbacks (laminas-view,
+                // guzzle) were silently swallowed pre-monolog. Tolerate and rely on
+                // monolog's fatal handler logging so user journeys continue.
                 $minorErrors = [
-                    E_WARNING, E_NOTICE, E_USER_NOTICE, E_DEPRECATED, E_USER_DEPRECATED
+                    E_WARNING, E_NOTICE, E_USER_NOTICE, E_DEPRECATED, E_USER_DEPRECATED, E_USER_ERROR
                 ];
                 if (null === $error || (isset($error['type']) && in_array($error['type'], $minorErrors))) {
                     return null;


### PR DESCRIPTION
## Description

Maintain same behaviour as laminas-log for the timebeing to avoid unexpected errors in some journeys

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
