### PR TITLE
fix: vol 5066 internal conviction text bug

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/ConvictionsPenaltiesData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/ConvictionsPenaltiesData.php
@@ -25,6 +25,7 @@ class ConvictionsPenaltiesData
      *     "legend-attributes": {"class": "form-element__label field"},
      *     "label_attributes": {"class": "form-control form-control--radio form-control--inline"},
      *     "value_options": {"Y": "Yes", "N": "No"},
+     *     "label_options": {"disable_html_escape": true},
      * })
      * @Form\Type("\Laminas\Form\Element\Radio")
      * @Form\Validator("Common\Form\Elements\Validators\LicenceHistoryLicenceValidator",

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/ConvictionsPenaltiesData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/ConvictionsPenaltiesData.php
@@ -24,7 +24,7 @@ class ConvictionsPenaltiesData
      *     "label": "selfserve-app-subSection-previous-history-criminal-conviction-hasConv-hint",
      *     "legend-attributes": {"class": "form-element__label field"},
      *     "label_attributes": {"class": "form-control form-control--radio form-control--inline"},
-     *     "value_options": {"Y": "Yes", "N": "No"q},
+     *     "value_options": {"Y": "Yes", "N": "No"},
      *     "label_options": {"disable_html_escape": true},
      * })
      * @Form\Type("\Laminas\Form\Element\Radio")

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/ConvictionsPenaltiesData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/ConvictionsPenaltiesData.php
@@ -24,7 +24,7 @@ class ConvictionsPenaltiesData
      *     "label": "selfserve-app-subSection-previous-history-criminal-conviction-hasConv-hint",
      *     "legend-attributes": {"class": "form-element__label field"},
      *     "label_attributes": {"class": "form-control form-control--radio form-control--inline"},
-     *     "value_options": {"Y": "Yes", "N": "No"},
+     *     "value_options": {"Y": "Yes", "N": "No"q},
      *     "label_options": {"disable_html_escape": true},
      * })
      * @Form\Type("\Laminas\Form\Element\Radio")


### PR DESCRIPTION
## Description

Fixes read-only view for internal users on the Convictions & Penalties page where the question label was rendering raw escaped HTML instead of formatted content, by setting disable_html_escape on the form element's label_options.

Related issue: [VOL-5066](https://dvsa.atlassian.net/browse/VOL-5066)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5066]: https://dvsa.atlassian.net/browse/VOL-5066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ