### PR TITLE
fix: vol 5427 certificate of roadworthiness vrm bug

### DIFF
--- a/Common/src/Common/Service/Qa/ValidatorsAdder.php
+++ b/Common/src/Common/Service/Qa/ValidatorsAdder.php
@@ -21,9 +21,7 @@ class ValidatorsAdder
             $validatorChain = $input->getValidatorChain();
 
             foreach ($validators as $validator) {
-                // tactical fix to allow entry of lower case registration number in certificate of
-                // roadworthiness journey. To be fixed correctly when we have more time
-                if ($validator['rule'] == \Dvsa\Olcs\Transfer\Validators\Vrm::class) {
+                if (ltrim($validator['rule'], '\\') == \Dvsa\Olcs\Transfer\Validators\Vrm::class) {
                     $filterChain = $input->getFilterChain();
                     $filterChain->attachByName(VrmFilter::class);
                 }


### PR DESCRIPTION
## Description

Lowercase vehicle registration numbers were being rejected on the certificate of roadworthiness VRN step despite a filter (Dvsa\Olcs\Transfer\Filter\Vrm) already existing to uppercase input before validation.
The filter was never being attached because the validator rule string returned by the backend includes a leading backslash (\Dvsa\Olcs\Transfer\Validators\Vrm), while ::class resolves without one, causing the equality check in ValidatorsAdder::add() to always fail silently.
Fixed by trimming the leading backslash before comparison.

Related issue: [VOL-5427](https://dvsa.atlassian.net/browse/VOL-5427)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5427]: https://dvsa.atlassian.net/browse/VOL-5427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ