### PR TITLE
fix: display correct restricted licence vehicle limit error message

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/OperatingCentreData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/OperatingCentreData.php
@@ -13,7 +13,6 @@ class OperatingCentreData
      * @Form\Attributes({"class":"tiny","pattern":"\d*","id":"noOfVehiclesRequired"})
      * @Form\Options({
      *     "label": "application_operating-centres_authorisation-sub-action.data.noOfVehiclesRequired",
-     *     "error-message": "Your total number of vehicles"
      * })
      * @Form\Validator("Between", options={"min":0, "max":1000000})
      */


### PR DESCRIPTION
## Description

Fixes the error message shown when too many vehicles are added on a restricted licence, which was displaying a hardcoded string instead of the translated message from the database. Updated the translation key grabbed from database to the correct message.

Related issue: [VOL-6117](https://dvsa.atlassian.net/browse/VOL-6117)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6117]: https://dvsa.atlassian.net/browse/VOL-6117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ