### PR TITLE
fix: vol 5401 schedule 41 licence validation bug

### DIFF
--- a/Common/src/Common/Controller/Lva/Schedule41Controller.php
+++ b/Common/src/Common/Controller/Lva/Schedule41Controller.php
@@ -334,13 +334,13 @@ class Schedule41Controller extends AbstractController
      */
     private function isLicenceValid($licenceNumber)
     {
-        $response = $this->handleQuery(
-            LicenceByNumber::create(
-                [
-                    'licenceNumber' => $licenceNumber
-                ]
-            )
-        );
+        try {
+            $response = $this->handleQuery(
+                LicenceByNumber::create(['licenceNumber' => $licenceNumber])
+            );
+        } catch (\Common\Service\Cqrs\Exception\NotFoundException $e) {
+            return ['number-not-valid' => ['application.schedule41.licence-number-not-valid']];
+        }
 
         if (!$response->isOk()) {
             $errors['number-not-valid'][] = 'application.schedule41.licence-number-not-valid';

--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/OperatingCentreData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/OperatingCentreData.php
@@ -13,7 +13,6 @@ class OperatingCentreData
      * @Form\Attributes({"class":"tiny","pattern":"\d*","id":"noOfVehiclesRequired"})
      * @Form\Options({
      *     "label": "application_operating-centres_authorisation-sub-action.data.noOfVehiclesRequired",
-     *     "error-message": "Your total number of vehicles"
      * })
      * @Form\Validator("Between", options={"min":0, "max":1000000})
      */


### PR DESCRIPTION
## Description

Adding a schedule 41 with an invalid or not found licence caused the page to crash as licence query returned a not found exception that was not being handled. 

Related issue: [VOL-5401](https://dvsa.atlassian.net/browse/VOL-5401)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-5401]: https://dvsa.atlassian.net/browse/VOL-5401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ