### PR TITLE
fix: vol 6118 filtering open cases bug

### DIFF
--- a/Common/src/Common/Form/Model/Form/Lva/Fieldset/OperatingCentreData.php
+++ b/Common/src/Common/Form/Model/Form/Lva/Fieldset/OperatingCentreData.php
@@ -13,7 +13,6 @@ class OperatingCentreData
      * @Form\Attributes({"class":"tiny","pattern":"\d*","id":"noOfVehiclesRequired"})
      * @Form\Options({
      *     "label": "application_operating-centres_authorisation-sub-action.data.noOfVehiclesRequired",
-     *     "error-message": "Your total number of vehicles"
      * })
      * @Form\Validator("Between", options={"min":0, "max":1000000})
      */

--- a/Common/src/Common/Service/Table/Formatter/CaseEntityNrStatus.php
+++ b/Common/src/Common/Service/Table/Formatter/CaseEntityNrStatus.php
@@ -63,6 +63,9 @@ class CaseEntityNrStatus implements FormatterPluginManagerInterface
 
         //  application
         $app = $data['application'];
+        if (empty($app)) {
+            return sprintf(self::TEMPLATE_LIC, $licLink, $licStatus);
+        }
         $appId = $app['id'];
 
         $appLink = sprintf(

--- a/test/Common/src/Common/Service/Table/Formatter/CaseEntityNrStatusTest.php
+++ b/test/Common/src/Common/Service/Table/Formatter/CaseEntityNrStatusTest.php
@@ -116,4 +116,34 @@ class CaseEntityNrStatusTest extends MockeryTestCase
             $this->sut->format($data, null)
         );
     }
+
+    public function testFormatAppWithNoApplication(): void
+    {
+        $licId = 9999;
+
+        $this->mockUrlHlp
+            ->shouldReceive('fromRoute')
+            ->with('lva-licence', ['licence' => $licId])
+            ->once()
+            ->andReturn('EXPECT_LIC_URL');
+
+        $data = [
+            'caseType' => [
+                'id' => \Common\RefData::CASE_TYPE_APPLICATION,
+            ],
+            'licence' => [
+                'id' => $licId,
+                'status' => [
+                    'description' => 'unit_LicStatus',
+                ],
+                'licNo' => 'unit_LicNo',
+            ],
+            'application' => null,
+        ];
+
+        static::assertSame(
+            '<a class="govuk-link" href="EXPECT_LIC_URL">unit_LicNo</a> (unit_LicStatus)',
+            $this->sut->format($data, null)
+        );
+    }
 }


### PR DESCRIPTION
## Description

Bug occurred of instances where cases had licences and no application attached. Added code that addresses this gap, and added thorough testing for this instance. Checked other case scenarios such as licences, tm cases, but these are already addressed.

  Related issue: [VOL-6118](https://dvsa.atlassian.net/browse/VOL-6118)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?


[VOL-6118]: https://dvsa.atlassian.net/browse/VOL-6118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ